### PR TITLE
concat argo role name with cluster name

### DIFF
--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -144,7 +144,7 @@ module "iam_assumable_role_argo_admin" {
 
   create_role = true
 
-  role_name = "Argo"
+  role_name = "Argo-${local.cluster_name}"
 
   tags = {
     Role = "Argo"


### PR DESCRIPTION
With this PR we concat cluster name on argo role name to avoid conflict, supporting more than one kubefirst cluster on same AWS account.