### PR TITLE
aws_node_termination_handler

### DIFF
--- a/registry/aws-node-termination-handler.yaml
+++ b/registry/aws-node-termination-handler.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-node-termination-handler
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: 'https://aws.github.io/eks-charts'
+    targetRevision: 0.19.0
+    helm:
+      values: |-
+        enableSpotInterruptionDraining: true
+        enableRebalanceMonitoring: true
+        enableScheduledEventDraining: true
+    chart: aws-node-termination-handler
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
With this PR we add the aws_node_termination_handler addon to deal when a node experiences some interruptions (e.g., spot instance termination) draining the node safely, moving the workload to another node, and keeping the apps running smoothly.

Signed-off-by: Thiago Pagotto <pagottoo@gmail.com>