### PR TITLE
Add gh webhook secret of atlantis

### DIFF
--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -9,8 +9,12 @@ terraform {
 
 
 provider "aws" {
-
   region = var.aws_region
+  default_tags {
+    tags = {
+      ClusterName = "<CLUSTER_NAME>"
+    }
+  }
 }
 module "eks" {
   source = "./eks"

--- a/terraform/ecr/main.tf
+++ b/terraform/ecr/main.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = "<AWS_DEFAULT_REGION>"
+  
+  default_tags {
+    tags = {
+      ClusterName = "<CLUSTER_NAME>"
+    }
+  }
 }
 
 resource "aws_ecr_repository" "ecr_repo_metaphor" {

--- a/terraform/gitlab/kubefirst-repos.tf
+++ b/terraform/gitlab/kubefirst-repos.tf
@@ -8,6 +8,11 @@ terraform {
 }
 provider "aws" {
   region = "<AWS_DEFAULT_REGION>"
+  default_tags {
+    tags = {
+      ClusterName = "<CLUSTER_NAME>"
+    }
+  }
 }
 
 resource "gitlab_group" "kubefirst" {

--- a/terraform/vault/bootstrap/k8s-auth-backend.tf
+++ b/terraform/vault/bootstrap/k8s-auth-backend.tf
@@ -8,6 +8,12 @@ data "terraform_remote_state" "eks" {
 }
 provider "aws" {
   region = "<AWS_DEFAULT_REGION>"
+  default_tags {
+    tags = {
+      ClusterName = "<CLUSTER_NAME>"
+    }
+  }
+
 }
 
 data "aws_eks_cluster" "cluster" {

--- a/terraform/vault/bootstrap/secrets.tf
+++ b/terraform/vault/bootstrap/secrets.tf
@@ -9,7 +9,7 @@ locals {
   		"ATLANTIS_GH_HOSTNAME": "<GITHUB_HOST>",
   		"ATLANTIS_GH_TOKEN": "<GITHUB_TOKEN>",
   		"ATLANTIS_GH_USER": "<GITHUB_USER>",		 
-      "ATLANTIS_GH_SECRET":  "${var.atlantis_github_webhook_token}",
+  		"ATLANTIS_GH_SECRET":  "${var.atlantis_github_webhook_token}",
   		"AWS_DEFAULT_REGION": "<AWS_DEFAULT_REGION>",
   		"AWS_ROLE_TO_ASSUME": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/KubernetesAdmin",
   		"AWS_SESSION_NAME": "GitHubAction",

--- a/terraform/vault/bootstrap/secrets.tf
+++ b/terraform/vault/bootstrap/secrets.tf
@@ -9,6 +9,7 @@ locals {
   		"ATLANTIS_GH_HOSTNAME": "<GITHUB_HOST>",
   		"ATLANTIS_GH_TOKEN": "<GITHUB_TOKEN>",
   		"ATLANTIS_GH_USER": "<GITHUB_USER>",		 
+      "ATLANTIS_GH_SECRET":  "${var.atlantis_github_webhook_token}",
   		"AWS_DEFAULT_REGION": "<AWS_DEFAULT_REGION>",
   		"AWS_ROLE_TO_ASSUME": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/KubernetesAdmin",
   		"AWS_SESSION_NAME": "GitHubAction",

--- a/terraform/vault/bootstrap/secrets.tf
+++ b/terraform/vault/bootstrap/secrets.tf
@@ -15,7 +15,17 @@ locals {
   		"AWS_SESSION_NAME": "GitHubAction",
   		"KUBECONFIG": "/.kube/config",
   		"VAULT_ADDR": "https://vault.<AWS_HOSTED_ZONE_NAME>",
-  		"VAULT_TOKEN": "${var.vault_token}"
+  		"VAULT_TOKEN": "${var.vault_token}",
+  		"TF_VAR_argo_redirect_uris": "[\"https://argo.<AWS_HOSTED_ZONE_NAME>/oauth2/callback\"]",
+  		"TF_VAR_argocd_redirect_uris": "[\"https://argocd.<AWS_HOSTED_ZONE_NAME>/auth/callback\",\"https://argocd.<AWS_HOSTED_ZONE_NAME>/applications\"]",
+  		"TF_VAR_aws_account_id": "<AWS_ACCOUNT_ID>",
+  		"TF_VAR_aws_region": "<AWS_DEFAULT_REGION>",
+  		"TF_VAR_email_address": "${var.email_address}",
+  		"TF_VAR_hosted_zone_id": "${var.hosted_zone_id}",
+  		"TF_VAR_hosted_zone_name": "${var.hosted_zone_name}",
+  		"TF_VAR_vault_addr": "${var.vault_addr}",
+  		"TF_VAR_vault_redirect_uris": "[\"https://vault.<AWS_HOSTED_ZONE_NAME>/ui/vault/auth/oidc/oidc/callback\",\"http://localhost:8200/ui/vault/auth/oidc/oidc/callback\",\"http://localhost:8250/oidc/callback\",\"https://vault.<AWS_HOSTED_ZONE_NAME>:8250/oidc/callback\"]",
+  		"TF_VAR_vault_token": "${var.vault_token}"
   	}
 }
 EOT

--- a/terraform/vault/bootstrap/variables.tf
+++ b/terraform/vault/bootstrap/variables.tf
@@ -22,6 +22,10 @@ variable "gitlab_runner_token" {
 variable "gitlab_token" {
   type = string
 }
+variable "atlantis_github_webhook_token" {
+  description = "GitHub Webhook token to be used on atlantis"
+  type = string
+}
 variable "hosted_zone_name" {
   type = string
 }

--- a/terraform/vault/main.tf
+++ b/terraform/vault/main.tf
@@ -21,6 +21,7 @@ module "bootstrap" {
   gitlab_token         = var.gitlab_token
   git_provider         = var.git_provider
   ssh_private_key      = var.ssh_private_key
+  atlantis_github_webhook_token = var.atlantis_github_webhook_token
 }
 
 module "oidc" {

--- a/terraform/vault/variables.tf
+++ b/terraform/vault/variables.tf
@@ -22,6 +22,10 @@ variable "gitlab_runner_token" {
 variable "gitlab_token" {
   type = string
 }
+variable "atlantis_github_webhook_token" {
+  description = "GitHub Webhook token to be used on atlantis"
+  type = string
+}
 variable "hosted_zone_name" {
   type = string
 }


### PR DESCRIPTION
With this PR we persist on Vault the token used on webhook configuration in the GitHub repository and use on secret inject in Atlantis.
PLUS: added default tag to ensure that all resources have the tag cluster_name.

Related with: https://github.com/kubefirst/kubefirst/pull/433 and also close https://github.com/kubefirst/kubefirst/issues/398