### PR TITLE
stop actions-runner-controller thrashing

### DIFF
--- a/components/github-runner/github-runner.yaml
+++ b/components/github-runner/github-runner.yaml
@@ -18,4 +18,3 @@ spec:
       serviceAccountName: github-runner
       dockerdWithinRunnerContainer: true
       automountServiceAccountToken: true
-      env: []  


### PR DESCRIPTION
this adjustment is needed to prevent argocd from endlessly cycling between our desired [] and the actual empty element that results from applying this config. unsetting it causes the app to cleanly sync and not thrash.