### PR TITLE
eks graviton support

### DIFF
--- a/components/argo-cwfts/cwft-docker.yaml
+++ b/components/argo-cwfts/cwft-docker.yaml
@@ -18,7 +18,7 @@ spec:
         default: <AWS_DEFAULT_REGION>
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: ciCommitSha
       - name: containerRegistryUrl
         value: "{{workflow.parameters.containerRegistryUrl}}"
@@ -33,7 +33,7 @@ spec:
       args:
         - until docker ps; do sleep 3; done; 
           docker build -t "{{inputs.parameters.containerRegistryUrl}}/{{inputs.parameters.appName}}:{{inputs.parameters.ciCommitSha}}" -f {{inputs.parameters.dockerFilePath}} .;
-          aws ecr get-login-password --region {{inputs.parameters.awsRegion}} | docker login --username AWS --password-stdin {{inputs.parameters.containerRegistryUrl}};
+          docker login -u AWS -p $(aws ecr get-login-password --region {{inputs.parameters.awsRegion}}) {{inputs.parameters.containerRegistryUrl}};
           docker push "{{inputs.parameters.containerRegistryUrl}}/{{inputs.parameters.appName}}:{{inputs.parameters.ciCommitSha}}";
       envFrom:
       - secretRef:

--- a/components/argo-cwfts/cwft-git.yaml
+++ b/components/argo-cwfts/cwft-git.yaml
@@ -13,7 +13,7 @@ spec:
         default: main
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: gitopsRepoUrl
         value: "{{workflow.parameters.gitopsRepoUrl}}"
         default: "ssh://<FULL_REPO_GITOPS_URL>"
@@ -58,7 +58,7 @@ spec:
         default: main
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: gitopsRepoUrl
         value: "{{workflow.parameters.gitopsRepoUrl}}"
         default: <FULL_REPO_GITOPS_URL>

--- a/components/argo-cwfts/cwft-helm.yaml
+++ b/components/argo-cwfts/cwft-helm.yaml
@@ -16,7 +16,7 @@ spec:
       - name: appDir
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: chartDir
       - name: chartRepoName
         value: "{{workflow.parameters.chartRepoName}}"
@@ -56,7 +56,7 @@ spec:
       workingDir: "{{inputs.parameters.appDir}}"
       args:
       - helm repo add {{inputs.parameters.chartRepoName}} {{inputs.parameters.chartRepoUrl}} --username $BASIC_AUTH_USER --password $BASIC_AUTH_PASS || bash -c "sleep 10 && echo 'waiting before trying again' && exit 1";
-        helm push {{inputs.parameters.chartDir}} {{inputs.parameters.chartRepoName}} || bash -c "sleep 10 && echo 'waiting before trying again' && exit 1";
+        helm cm-push {{inputs.parameters.chartDir}} {{inputs.parameters.chartRepoName}} || bash -c "sleep 10 && echo 'waiting before trying again' && exit 1";
       envFrom:
       - secretRef:
           name: ci-secrets
@@ -102,7 +102,7 @@ spec:
       - name: appDir
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: chartDir
       - name: chartVersion
       - name: ciCommitSha
@@ -145,7 +145,7 @@ spec:
         - name: appDir
         - name: buildImage
           value: "{{workflow.parameters.buildImage}}"
-          default: kubefirst/chubbo:0.1
+          default: pagottoo/ci-tools:v3
         - name: chartDir
     script:
       image: "{{inputs.parameters.buildImage}}"
@@ -165,7 +165,7 @@ spec:
       parameters: 
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: fullChartPath
       - name: chartVersion
       - name: environment
@@ -193,7 +193,7 @@ spec:
       - name: appDir
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: chartDir
       - name: chartVersion
     # version bumps the patch verison of the helm chart version

--- a/components/argo-cwfts/cwft-npm.yaml
+++ b/components/argo-cwfts/cwft-npm.yaml
@@ -15,7 +15,7 @@ spec:
       - name: appDir
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
     container:
       image:  "{{inputs.parameters.buildImage}}"
       command: [bash, -c]
@@ -36,7 +36,7 @@ spec:
       - name: appDir
       - name: buildImage
         value: "{{workflow.parameters.buildImage}}"
-        default: kubefirst/chubbo:0.1
+        default: pagottoo/ci-tools:v3
       - name: npmRunScript
     container:
       image: "{{inputs.parameters.buildImage}}"

--- a/components/atlantis/application.yaml
+++ b/components/atlantis/application.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: 'https://runatlantis.github.io/helm-charts'
     chart: atlantis
-    targetRevision: 3.15.0
+    targetRevision: 4.1.1
     helm:
       parameters:
         - name: ingress.host

--- a/components/external-secrets-store/vault-cluster-secret-store-secret.yaml
+++ b/components/external-secrets-store/vault-cluster-secret-store-secret.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: argocd-server
       containers:
       - name: c
-        image: sverrirab/sleep:latest
+        image: portainer/kubectl-shell:latest-v1.21.1-arm64
         command:
         - /bin/sh
         - -c

--- a/components/external-secrets-store/vault-cluster-secret-store-secret.yaml
+++ b/components/external-secrets-store/vault-cluster-secret-store-secret.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: argocd-server
       containers:
       - name: c
-        image: portainer/kubectl-shell:latest-v1.21.1-arm64
+        image: portainer/kubectl-shell:latest
         command:
         - /bin/sh
         - -c

--- a/components/kubefirst/vouch.yaml
+++ b/components/kubefirst/vouch.yaml
@@ -14,7 +14,7 @@ spec:
     helm:
       values: |-
         image:
-          repository: voucher/vouch-proxy
+          repository: <VOUCH_DOCKER_REGISTRY>
           tag: <VOUCH_DOCKER_TAG>
           pullPolicy: IfNotPresent
         ingress:

--- a/components/kubefirst/vouch.yaml
+++ b/components/kubefirst/vouch.yaml
@@ -13,6 +13,10 @@ spec:
     chart: vouch
     helm:
       values: |-
+        image:
+          repository: voucher/vouch-proxy
+          tag: latest-arm
+          pullPolicy: IfNotPresent
         ingress:
           enabled: true
           annotations:

--- a/components/kubefirst/vouch.yaml
+++ b/components/kubefirst/vouch.yaml
@@ -15,7 +15,7 @@ spec:
       values: |-
         image:
           repository: voucher/vouch-proxy
-          tag: latest-arm
+          tag: <VOUCH_DOCKER_TAG>
           pullPolicy: IfNotPresent
         ingress:
           enabled: true

--- a/components/vault/vault-unseal.yaml
+++ b/components/vault/vault-unseal.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: vault-unseal-sa
       containers:
       - name: unseal-vault
-        image: rancher/kubectl:v1.20.15
+        image: portainer/kubectl-shell:latest-v1.21.1-arm64
         command:
         - /bin/sh
         - -c

--- a/components/vault/vault-unseal.yaml
+++ b/components/vault/vault-unseal.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: vault-unseal-sa
       containers:
       - name: unseal-vault
-        image: public.ecr.aws/bitnami/kubectl:1.20
+        image: rancher/kubectl:v1.20.15
         command:
         - /bin/sh
         - -c

--- a/components/vault/vault-unseal.yaml
+++ b/components/vault/vault-unseal.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: vault-unseal-sa
       containers:
       - name: unseal-vault
-        image: portainer/kubectl-shell:latest-v1.21.1-arm64
+        image: portainer/kubectl-shell:latest
         command:
         - /bin/sh
         - -c

--- a/registry/external-dns.yaml
+++ b/registry/external-dns.yaml
@@ -14,8 +14,8 @@ spec:
   project: default
   source:
     chart: external-dns
-    repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 6.5.4
+    repoURL: https://kubernetes-sigs.github.io/external-dns/
+    targetRevision: 1.11.0
     helm:
       releaseName: external-dns
       values: |

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -209,7 +209,7 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
   ami_type        = "AL2_ARM_64"
-  instance_types  = ["m6g.medium"]
+  #instance_types  = ["m6g.medium"]
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -208,7 +208,7 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_group_name = "mgmt-nodes"
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
-  ami_type        = "AL2_x86_64"
+  ami_type        = "AL2_ARM_64"
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -209,7 +209,7 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
   ami_type        = "AL2_ARM_64"
-  #instance_types  = ["m6g.medium"]
+  instance_types  = ["m6g.medium"]
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -209,7 +209,7 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
   ami_type        = var.ami_type
-  instance_types  = var.instance_types
+  instance_types  = [var.instance_type]
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -208,8 +208,8 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_group_name = "mgmt-nodes"
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
-  ami_type        = "AL2_ARM_64"
-  instance_types  = ["m6g.medium"]
+  ami_type        = var.ami_type
+  instance_types  = var.instance_types
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -209,6 +209,7 @@ resource "aws_eks_node_group" "mgmt_nodes" {
   node_role_arn   = aws_iam_role.kubefirst_worker_nodes_role.arn
   subnet_ids      = module.vpc.private_subnets
   ami_type        = "AL2_ARM_64"
+  instance_types  = ["m6g.medium"]
   disk_size       = 50
 
   capacity_type = var.lifecycle_nodes

--- a/terraform/base/eks/variables.tf
+++ b/terraform/base/eks/variables.tf
@@ -58,6 +58,6 @@ variable "instance_types" {
 
 variable "ami_type" {
   description = "The chipset of nodes"
-  default = ["AL2_x86_64"]
-  type = list(string)
+  default = "AL2_x86_64"
+  type = string
 }

--- a/terraform/base/eks/variables.tf
+++ b/terraform/base/eks/variables.tf
@@ -49,3 +49,15 @@ variable "lifecycle_nodes" {
   default = "ON_DEMAND"
   type = string
 }
+
+variable "instance_types" {
+  description = "The instance type of node group"
+  default = "t3.medium"
+  type = string
+}
+
+variable "ami_type" {
+  description = "The chipset of nodes"
+  default = "AL2_x86_64"
+  type = string
+}

--- a/terraform/base/eks/variables.tf
+++ b/terraform/base/eks/variables.tf
@@ -50,7 +50,7 @@ variable "lifecycle_nodes" {
   type = string
 }
 
-variable "instance_types" {
+variable "instance_type" {
   description = "The instance type of node group"
   default = "t3.medium"
   type = string

--- a/terraform/base/eks/variables.tf
+++ b/terraform/base/eks/variables.tf
@@ -58,6 +58,6 @@ variable "instance_types" {
 
 variable "ami_type" {
   description = "The chipset of nodes"
-  default = "AL2_x86_64"
-  type = string
+  default = ["AL2_x86_64"]
+  type = list(string)
 }

--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -19,11 +19,11 @@ provider "aws" {
 module "eks" {
   source = "./eks"
 
-  aws_account_id = var.aws_account_id
-  cluster_name   = "<CLUSTER_NAME>"
+  aws_account_id  = var.aws_account_id
+  cluster_name    = "<CLUSTER_NAME>"
   lifecycle_nodes = var.lifecycle_nodes
   ami_type        = var.ami_type
-  instance_type  = [var.instance_type]
+  instance_type   = var.instance_type
 }
 
 module "kms" {

--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -22,6 +22,8 @@ module "eks" {
   aws_account_id = var.aws_account_id
   cluster_name   = "<CLUSTER_NAME>"
   lifecycle_nodes = var.lifecycle_nodes
+  ami_type        = var.ami_type
+  instance_types  = [var.instance_type]
 }
 
 module "kms" {

--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -23,7 +23,7 @@ module "eks" {
   cluster_name   = "<CLUSTER_NAME>"
   lifecycle_nodes = var.lifecycle_nodes
   ami_type        = var.ami_type
-  instance_types  = [var.instance_type]
+  instance_type  = [var.instance_type]
 }
 
 module "kms" {

--- a/terraform/base/variables.tf
+++ b/terraform/base/variables.tf
@@ -15,3 +15,15 @@ variable "lifecycle_nodes" {
   default = "ON_DEMAND"
   type = string
 }
+
+variable "instance_type" {
+  description = "The instance type of node group"
+  default = "t3.medium"
+  type = string
+}
+
+variable "ami_type" {
+  description = "The chipset of nodes"
+  default = "AL2_x86_64"
+  type = string
+}


### PR DESCRIPTION
To achieve support on graviton compute nodes in aws eks, this pr change some resources:

terraform to accept variables instance_type and ami_types to change computes nodes to have graviton;
some helm charts, or overwrite docker images to support graviton/arm on aws eks compute nodes;

Related: https://github.com/kubefirst/kubefirst/pull/702