### PR TITLE
enable development by default and fix metaphor frontend

### DIFF
--- a/localhost/components/development/metaphor-frontend/values.yaml
+++ b/localhost/components/development/metaphor-frontend/values.yaml
@@ -5,3 +5,7 @@ metaphor-frontend:
   - name: docker-config
   ingress:
     enabled: false
+  metaphor:
+    host: http://localhost:3000
+  metaphorGo:
+    host: http://localhost:5000

--- a/localhost/components/production/metaphor-frontend/values.yaml
+++ b/localhost/components/production/metaphor-frontend/values.yaml
@@ -5,3 +5,7 @@ metaphor-frontend:
   - name: docker-config
   ingress:
     enabled: false
+  metaphor:
+    host: http://localhost:3002
+  metaphorGo:
+    host: http://localhost:5002

--- a/localhost/components/staging/metaphor-frontend/values.yaml
+++ b/localhost/components/staging/metaphor-frontend/values.yaml
@@ -5,3 +5,7 @@ metaphor-frontend:
   - name: docker-config
   ingress:
     enabled: false
+  metaphor:
+    host: http://localhost:3001
+  metaphorGo:
+    host: http://localhost:5001

--- a/localhost/registry/development.yaml
+++ b/localhost/registry/development.yaml
@@ -1,24 +1,24 @@
-# apiVersion: argoproj.io/v1alpha1
-# kind: Application
-# metadata:
-#   name: development
-#   namespace: argocd
-#   finalizers:
-#   - resources-finalizer.argocd.argoproj.io
-#   annotations:
-#     argocd.argoproj.io/sync-wave: "40"
-# spec:
-#   project: default
-#   source:
-#     repoURL: <FULL_REPO_GITOPS_URL_HTTPS>
-#     path: components/development
-#     targetRevision: HEAD
-#   destination:
-#     server: https://kubernetes.default.svc
-#     namespace: development
-#   syncPolicy:
-#     automated:
-#       prune: true
-#       selfHeal: true
-#     syncOptions:
-#       - CreateNamespace=true
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: development
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+spec:
+  project: default
+  source:
+    repoURL: <FULL_REPO_GITOPS_URL_HTTPS>
+    path: components/development
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: development
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
this changeset will adjust the local experience such that the development environment will be enabled by default.
this will also provide the appropriate override values for frontend to reach the backend api over the expected port forwards.