### PR TITLE
change internal tags to use provider default tags

### DIFF
--- a/terraform/base/dynamodb/vault.tf
+++ b/terraform/base/dynamodb/vault.tf
@@ -73,8 +73,6 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
     Name          = "vault-backend-<CLUSTER_NAME>"
     VaultInstance = "vault"
     Environment   = "mgmt"
-    ClusterName   = "<CLUSTER_NAME>"
-    ProvisionedBy = "kubefirst"
   }
 
   lifecycle {

--- a/terraform/base/eks/main.tf
+++ b/terraform/base/eks/main.tf
@@ -94,10 +94,6 @@ module "vpc" {
     "kubernetes.io/role/internal-elb"             = "1"
   }
 
-  vpc_tags = {
-    "ClusterName"   = "${local.cluster_name}"
-    "ProvisionedBy" = "kubefirst"
-  }
 }
 
 module "eks" {
@@ -112,11 +108,6 @@ module "eks" {
   
   kubeconfig_output_path = "./kubeconfig"
     
-  tags = {
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
-  }
-
   vpc_id = module.vpc.vpc_id
 }
 
@@ -133,8 +124,6 @@ module "iam_assumable_role_argo_admin" {
   ]
   tags = {
     Role = "Argo"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
   
@@ -151,8 +140,6 @@ module "iam_assumable_role_atlantis_admin" {
   ]
   tags = {
     Role = "Atlantis"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
 
@@ -169,8 +156,6 @@ module "iam_assumable_role_cert_manager_route53" {
   ]
   tags = {
     Role = "CertManager"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
 
@@ -220,8 +205,6 @@ module "iam_assumable_role_chartmuseum_s3" {
   ]
   tags = {
     Role = "Chartmuseum"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
 
@@ -238,8 +221,6 @@ module "iam_assumable_role_external_dns_route53" {
   ]
   tags = {
     Role = "ExternalDns"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
 
@@ -291,8 +272,6 @@ module "iam_assumable_role_vault_dynamo_kms" {
   ]
   tags = {
     Role = "Vault"
-    ClusterName = "${local.cluster_name}"
-    ProvisionedBy = "kubefirst"
   }
 }
 

--- a/terraform/base/kms/main.tf
+++ b/terraform/base/kms/main.tf
@@ -83,9 +83,6 @@ resource "aws_kms_key" "vault_unseal" {
 }
 EOT
   
-  tags = {
-    Name = "<CLUSTER_NAME>"
-  }
 }
 
 resource "aws_kms_alias" "vault_unseal" {

--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -13,6 +13,7 @@ provider "aws" {
   default_tags {
     tags = {
       ClusterName = "<CLUSTER_NAME>"
+      ProvisionedBy = "kubefirst"
     }
   }
 }

--- a/terraform/gitlab/kubefirst-repos.tf
+++ b/terraform/gitlab/kubefirst-repos.tf
@@ -11,6 +11,7 @@ provider "aws" {
   default_tags {
     tags = {
       ClusterName = "<CLUSTER_NAME>"
+      ProvisionedBy = "kubefirst"
     }
   }
 }

--- a/terraform/vault/k8s-auth-backend.tf
+++ b/terraform/vault/k8s-auth-backend.tf
@@ -12,6 +12,7 @@ provider "aws" {
   default_tags {
     tags = {
       ClusterName = "<CLUSTER_NAME>"
+      ProvisionedBy = "kubefirst"
     }
   }
 


### PR DESCRIPTION
with this PR we normalize the use of tags on tf resources to use tags on provider resources (default tags) instead of tags on each tf resource;
so we can centralize future changes and stop the fight between individual tags and default tags making noise changes during atlantis plan/apply;

Signed-off-by: Thiago Pagotto <pagottoo@gmail.com>