### PR TITLE
fix #809 - vars persisted on vault to atlantis

### DIFF
--- a/terraform/base/eks/variables.tf
+++ b/terraform/base/eks/variables.tf
@@ -1,14 +1,14 @@
-variable "ami_type" {
-  description = "The chipset of nodes"
-  default = "AL2_x86_64"
-  type = string
-}
-
 variable "aws_account_id" {
   type = string
 }
 
 variable "cluster_name" {
+  type = string
+}
+
+variable "ami_type" {
+  description = "The chipset of nodes"
+  default = "AL2_x86_64"
   type = string
 }
 

--- a/terraform/vault/secrets-github.tf
+++ b/terraform/vault/secrets-github.tf
@@ -42,6 +42,8 @@ resource "vault_generic_secret" "atlantis_secrets" {
 	TF_VAR_ssh_private_key = var.ssh_private_key
 	TF_VAR_vault_addr = var.vault_addr,
 	TF_VAR_vault_token = var.vault_token,
+	TF_VAR_ami_type = var.ami_type,
+	TF_VAR_instance_type = var.instance_type,
 	VAULT_ADDR = "https://vault.<AWS_HOSTED_ZONE_NAME>",
 	VAULT_TOKEN = var.vault_token,
 }

--- a/terraform/vault/variables.tf
+++ b/terraform/vault/variables.tf
@@ -47,3 +47,14 @@ variable "atlantis_repo_webhook_secret" {
   default = ""
   type = string 
 }
+variable "ami_type" {
+  description = "The chipset of nodes"
+  default = "AL2_x86_64"
+  type = string
+}
+
+variable "instance_type" {
+  description = "The instance type of node group"
+  default = "t3.medium"
+  type = string
+}


### PR DESCRIPTION
Persisting tf vars which values are changed by k1 flag in Atlantis secrets to solving the unexpected behavior of Atlantis plan/apply changing resources using default values.

Close:
- https://github.com/kubefirst/kubefirst/issues/809

Signed-off-by: Thiago Pagotto <pagottoo@gmail.com>