### PR TITLE
feat: include persistence to minio on localhost

### DIFF
--- a/localhost/components/minio/application.yaml
+++ b/localhost/components/minio/application.yaml
@@ -38,7 +38,8 @@ spec:
         rootUser: k-ray
         rootPassword: feedkraystars
         persistence:
-          enabled: false
+          enabled: true
+          existingClaim: minio-pv-claim
         resources:
           requests:
             memory: 500Mi

--- a/localhost/components/minio/pvc.yaml
+++ b/localhost/components/minio/pvc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pv-volume
+  namespace: minio
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/minio-storage"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pv-claim
+  namespace: minio
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
The new PVC will be used for minio backend to write on disk instead memory.

Signed-off-by: Jessica Marinho <jessica@kubeshop.io>