### PR TITLE
Fix dependency issue when creating Civo secrets

### DIFF
--- a/civo-github/terraform/civo/modules/secrets/main.tf
+++ b/civo-github/terraform/civo/modules/secrets/main.tf
@@ -1,0 +1,33 @@
+// Create in-cluster Secret containing kubeconfig
+// Referenced by dependent apps during setup
+provider "kubernetes" {
+  config_path = var.kube_config_path
+}
+
+// Kubefirst
+resource "kubernetes_secret_v1" "civo_cluster_kubeconfig_kubefirst_ns" {
+  metadata {
+    name      = "kube-config-ref"
+    namespace = "kubefirst"
+  }
+
+  data = {
+    ".kubeconfig" = var.kube_config_content
+  }
+
+  type = "Opaque"
+}
+
+// Atlantis
+resource "kubernetes_secret_v1" "civo_cluster_kubeconfig_atlantis_ns" {
+  metadata {
+    name      = "kube-config-ref"
+    namespace = "atlantis"
+  }
+
+  data = {
+    ".kubeconfig" = var.kube_config_content
+  }
+
+  type = "Opaque"
+}

--- a/civo-github/terraform/civo/modules/secrets/vars.tf
+++ b/civo-github/terraform/civo/modules/secrets/vars.tf
@@ -1,0 +1,7 @@
+variable "kube_config_path" {
+  type = string
+}
+
+variable "kube_config_content" {
+  type = string
+}


### PR DESCRIPTION
Should address this:

```bash
2023-02-17T10:23 WRN kubefirst/pkg/ExecShellWithVars/shell.go:77 > ERR: │ Error: Post "http://localhost/api/v1/namespaces/kubefirst/secrets": dial tcp [::1]:80: connect: connection refused
2023-02-17T10:23 INF kubefirst/pkg/ExecShellWithVars/shell.go:69 > OUT:   on main.tf line 58, in provider "kubernetes":
2023-02-17T10:23 WRN kubefirst/pkg/ExecShellWithVars/shell.go:77 > ERR: │
2023-02-17T10:23 INF kubefirst/pkg/ExecShellWithVars/shell.go:69 > OUT:   58: provider "kubernetes" {
2023-02-17T10:23 WRN kubefirst/pkg/ExecShellWithVars/shell.go:77 > ERR: │   with kubernetes_secret_v1.civo_cluster_kubeconfig_kubefirst_ns,
2023-02-17T10:23 INF kubefirst/pkg/ExecShellWithVars/shell.go:69 > OUT:
2023-02-17T10:23 WRN kubefirst/pkg/ExecShellWithVars/shell.go:77 > ERR: │   on main.tf line 63, in resource "kubernetes_secret_v1" "civo_cluster_kubeconfig_kubefirst_ns":
2023-02-17T10:23 INF kubefirst/pkg/ExecShellWithVars/shell.go:69 > OUT: 'config_path' refers to an invalid path: "../../../kubeconfig": stat
2023-02-17T10:23 WRN kubefirst/pkg/ExecShellWithVars/shell.go:77 > ERR: │   63: resource "kubernetes_secret_v1" "civo_cluster_kubeconfig_kubefirst_ns" {
2023-02-17T10:23 INF kubefirst/pkg/ExecShellWithVars/shell.go:69 > OUT: ../../../kubeconfig: no such file or directory
```