### PR TITLE
enhancement: org-wide github runners for cloud deploys

### DIFF
--- a/aws-github/.kubefirst/clusters/mgmt-template/components/github-runner/runnerdeployment.yaml
+++ b/aws-github/.kubefirst/clusters/mgmt-template/components/github-runner/runnerdeployment.yaml
@@ -3,12 +3,12 @@ kind: RunnerDeployment
 metadata:
   name: actions-runner-metaphor
   annotations:
-    argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-wave: '20'
 spec:
-  replicas: 1
+  replicas: 2
   template:
-    spec:  
-      repository: <GITHUB_OWNER>/metaphor
+    spec:
+      organization: <GITHUB_OWNER>
       image: summerwind/actions-runner-dind
       serviceAccountName: github-runner
       dockerdWithinRunnerContainer: true

--- a/civo-github/mgmt-cluster-template/components/github-runner/runnerdeployment.yaml
+++ b/civo-github/mgmt-cluster-template/components/github-runner/runnerdeployment.yaml
@@ -1,46 +1,14 @@
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
-  name: actions-runner-metaphor
+  name: actions-runner
   annotations:
     argocd.argoproj.io/sync-wave: '20'
 spec:
-  replicas: 1
+  replicas: 2
   template:
     spec:
-      repository: <GITHUB_OWNER>/metaphor
-      image: summerwind/actions-runner-dind
-      serviceAccountName: github-runner
-      dockerdWithinRunnerContainer: true
-      automountServiceAccountToken: true
----
-apiVersion: actions.summerwind.dev/v1alpha1
-kind: RunnerDeployment
-metadata:
-  name: actions-runner-metaphor-go
-  annotations:
-    argocd.argoproj.io/sync-wave: '20'
-spec:
-  replicas: 1
-  template:
-    spec:
-      repository: <GITHUB_OWNER>/metaphor-go
-      image: summerwind/actions-runner-dind
-      serviceAccountName: github-runner
-      dockerdWithinRunnerContainer: true
-      automountServiceAccountToken: true
----
-apiVersion: actions.summerwind.dev/v1alpha1
-kind: RunnerDeployment
-metadata:
-  name: actions-runner-metaphor-frontend
-  annotations:
-    argocd.argoproj.io/sync-wave: '20'
-spec:
-  replicas: 1
-  template:
-    spec:
-      repository: <GITHUB_OWNER>/metaphor-frontend
+      organization: <GITHUB_OWNER>
       image: summerwind/actions-runner-dind
       serviceAccountName: github-runner
       dockerdWithinRunnerContainer: true


### PR DESCRIPTION
Move away from using repository-scoped runners for cloud deployments.