### PR TITLE
fix: fix terraform failure on re-apply during destroy if obj is null

### DIFF
--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data != null ? module.eks.cluster_certificate_authority_data : "")
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"

--- a/aws-gitlab/terraform/aws/eks/main.tf
+++ b/aws-gitlab/terraform/aws/eks/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data != null ? module.eks.cluster_certificate_authority_data : "")
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"


### PR DESCRIPTION
Without this fix, running `aws destroy` more than once if there is a failure can end like this:

```bash
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: ╷
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │ Error: Invalid function argument
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │   on eks/main.tf line 7, in provider "kubernetes":
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │    7:   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │     ├────────────────
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │     │ while calling base64decode(str)
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │     │ module.eks.cluster_certificate_authority_data is null
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: │ Invalid value for "str" parameter: argument must not be null.
2023-03-20T15:41 WRN kubefirst/pkg/ExecShellWithVars/shell.go:97 > ERR: ╵
```

This uses a ternary and sets it to an empty string to avoid causing this error and getting a clean destroy.