### PR TITLE
fix: staging/production metaphor secrets paths

### DIFF
--- a/aws-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/aws-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -18,3 +18,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/aws-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/aws-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -18,3 +18,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/aws-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/aws-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -18,3 +18,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/aws-gitlab/cluster-types/mgmt/components/staging/metaphor.yaml
+++ b/aws-gitlab/cluster-types/mgmt/components/staging/metaphor.yaml
@@ -25,3 +25,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+  vaultSecretPath: staging/metaphor

--- a/aws-gitlab/cluster-types/mgmt/components/staging/metaphor.yaml
+++ b/aws-gitlab/cluster-types/mgmt/components/staging/metaphor.yaml
@@ -25,4 +25,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-  vaultSecretPath: staging/metaphor

--- a/aws-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/aws-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -18,3 +18,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/civo-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/civo-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/civo-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/civo-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/civo-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/civo-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/civo-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/civo-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/digitalocean-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/digitalocean-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/digitalocean-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/digitalocean-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/digitalocean-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/digitalocean-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/digitalocean-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/digitalocean-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/gcp-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/gcp-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/gcp-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/gcp-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/vultr-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/vultr-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/vultr-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/vultr-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor

--- a/vultr-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/vultr-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-production.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: production/metaphor

--- a/vultr-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/vultr-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
   metaphor:
     host: https://metaphor-staging.<DOMAIN_NAME>/api
     console: https://kubefirst.<DOMAIN_NAME>
+  vaultSecretPath: staging/metaphor


### PR DESCRIPTION
@sudowing reported vault secrets in metaphor staging/production aren't updating. turns out all non-k3d platforms are leveraging chart-default development/metaphor path. this fix addresses across all clouds.