### PR TITLE
feat- add option to destroy buckets

### DIFF
--- a/gcp-github/terraform/gcp/kms.tf
+++ b/gcp-github/terraform/gcp/kms.tf
@@ -1,7 +1,20 @@
+resource "random_string" "uniqeness" {
+  length           = 5
+  special          = false
+  lower            = true
+
+  lifecycle {
+    ignore_changes = [
+      length,
+      lower,
+    ]
+  }
+}
+
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}"
+  keyring  = "vault-${local.cluster_name}-${random_string.uniqeness.result}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-github/terraform/gcp/kms.tf
+++ b/gcp-github/terraform/gcp/kms.tf
@@ -14,7 +14,7 @@ resource "random_string" "uniqeness" {
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${random_string.uniqeness.result}"
+  keyring  = "vault-${local.cluster_name}-${lower(random_string.uniqeness.result)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-github/terraform/gcp/kms.tf
+++ b/gcp-github/terraform/gcp/kms.tf
@@ -1,4 +1,4 @@
-resource "random_string" "uniqeness" {
+resource "random_string" "uniqueness" {
   length           = 5
   special          = false
   lower            = true
@@ -14,7 +14,7 @@ resource "random_string" "uniqeness" {
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${lower(random_string.uniqeness.result)}"
+  keyring  = "vault-${local.cluster_name}-${lower(random_string.uniqueness.result)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-github/terraform/gcp/storage.tf
+++ b/gcp-github/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${lower(random_string.uniqeness.result)}"
+  bucket_name   = "vault-data-${local.cluster_name}-${lower(random_string.uniqueness.result)}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-github/terraform/gcp/storage.tf
+++ b/gcp-github/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqeness.result}"
+  bucket_name   = "vault-data-${local.cluster_name}-${lower(random_string.uniqeness.result)}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-github/terraform/gcp/storage.tf
+++ b/gcp-github/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}"
+  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqeness.result}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-github/terraform/gcp/storage.tf
+++ b/gcp-github/terraform/gcp/storage.tf
@@ -2,7 +2,7 @@ module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
   bucket_name   = "vault-data-${local.cluster_name}"
-  force_destroy = false
+  force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant
   # Dual-Region buckets are geo redundant.

--- a/gcp-github/terraform/gcp/variables.tf
+++ b/gcp-github/terraform/gcp/variables.tf
@@ -22,3 +22,10 @@ variable "project" {
 
   default = "<GCP_PROJECT>"
 }
+
+variable "force_destroy" {
+  description = "variable used to control bucket force destroy"
+  type        = bool
+
+  default = "false"
+}

--- a/gcp-gitlab/terraform/gcp/kms.tf
+++ b/gcp-gitlab/terraform/gcp/kms.tf
@@ -1,4 +1,4 @@
-resource "random_string" "uniqeness" {
+resource "random_string" "uniqueness" {
   length           = 5
   special          = false
   lower            = true
@@ -14,7 +14,7 @@ resource "random_string" "uniqeness" {
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${random_string.uniqeness.result}"
+  keyring  = "vault-${local.cluster_name}-${random_string.uniqueness.result}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-gitlab/terraform/gcp/kms.tf
+++ b/gcp-gitlab/terraform/gcp/kms.tf
@@ -1,7 +1,20 @@
+resource "random_string" "uniqeness" {
+  length           = 5
+  special          = false
+  lower            = true
+
+  lifecycle {
+    ignore_changes = [
+      length,
+      lower,
+    ]
+  }
+}
+
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}"
+  keyring  = "vault-${local.cluster_name}-${random_string.uniqeness.result}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-gitlab/terraform/gcp/storage.tf
+++ b/gcp-gitlab/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}"
+  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqeness.result}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-gitlab/terraform/gcp/storage.tf
+++ b/gcp-gitlab/terraform/gcp/storage.tf
@@ -2,7 +2,7 @@ module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
   bucket_name   = "vault-data-${local.cluster_name}"
-  force_destroy = false
+  force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant
   # Dual-Region buckets are geo redundant.

--- a/gcp-gitlab/terraform/gcp/storage.tf
+++ b/gcp-gitlab/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqeness.result}"
+  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqueness.result}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-gitlab/terraform/gcp/variables.tf
+++ b/gcp-gitlab/terraform/gcp/variables.tf
@@ -22,3 +22,10 @@ variable "project" {
 
   default = "<GCP_PROJECT>"
 }
+
+variable "force_destroy" {
+  description = "variable used to control bucket force destroy"
+  type        = bool
+
+  default = "false"
+}


### PR DESCRIPTION
if you can't force destroy the bucket then the destroy function fails and things don't clean up.

Somethings in gcp don't delete right away and the names cannot be reused. The random string (which shouldn't change) will allow us to reuse the cluster name without conflicting resources that either don't clean up right away or have restrictions on name reuse.