### PR TITLE
fix: add uniqueness from code instead of terraform

### DIFF
--- a/gcp-github/cluster-types/mgmt/components/vault/application.yaml
+++ b/gcp-github/cluster-types/mgmt/components/vault/application.yaml
@@ -40,7 +40,7 @@ spec:
               }
               seal "gcpckms" {
                 crypto_key  = "vault-unseal"
-                key_ring    = "vault-<CLUSTER_NAME>"
+                key_ring    = "vault-<CLUSTER_NAME>-<GCP_UNIQUENESS>"
                 project     = "<GCP_PROJECT>"
                 region      = "global"
               }

--- a/gcp-github/terraform/gcp/kms.tf
+++ b/gcp-github/terraform/gcp/kms.tf
@@ -3,7 +3,7 @@
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${lower(var.uniquness)}"
+  keyring  = "vault-${local.cluster_name}-${lower(var.uniqueness)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-github/terraform/gcp/kms.tf
+++ b/gcp-github/terraform/gcp/kms.tf
@@ -1,20 +1,9 @@
-resource "random_string" "uniqueness" {
-  length           = 5
-  special          = false
-  lower            = true
 
-  lifecycle {
-    ignore_changes = [
-      length,
-      lower,
-    ]
-  }
-}
 
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${lower(random_string.uniqueness.result)}"
+  keyring  = "vault-${local.cluster_name}-${lower(var.uniquness)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-github/terraform/gcp/storage.tf
+++ b/gcp-github/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${lower(random_string.uniqueness.result)}"
+  bucket_name   = "vault-data-${local.cluster_name}-${lower(var.uniqueness)}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-github/terraform/gcp/terraform.tfvars
+++ b/gcp-github/terraform/gcp/terraform.tfvars
@@ -1,0 +1,2 @@
+force_destroy = <TERRAFORM_FORCE_DESTROY>
+uniqueness = "<GOOGLE_UNIQUENESS>"

--- a/gcp-github/terraform/gcp/variables.tf
+++ b/gcp-github/terraform/gcp/variables.tf
@@ -29,3 +29,8 @@ variable "force_destroy" {
 
   default = "false"
 }
+
+variable "uniqueness" {
+  description = "variable used to acoid collision amongst immutable resource names"
+  type        = string
+}

--- a/gcp-github/terraform/gcp/variables.tf
+++ b/gcp-github/terraform/gcp/variables.tf
@@ -31,6 +31,6 @@ variable "force_destroy" {
 }
 
 variable "uniqueness" {
-  description = "variable used to acoid collision amongst immutable resource names"
+  description = "variable used to avoid collision amongst immutable resource names"
   type        = string
 }

--- a/gcp-gitlab/cluster-types/mgmt/components/vault/application.yaml
+++ b/gcp-gitlab/cluster-types/mgmt/components/vault/application.yaml
@@ -40,7 +40,7 @@ spec:
               }
               seal "gcpckms" {
                 crypto_key  = "vault-unseal"
-                key_ring    = "vault-<CLUSTER_NAME>"
+                key_ring    = "vault-<CLUSTER_NAME>-<GCP_UNIQUENESS>"
                 project     = "<GCP_PROJECT>"
                 region      = "global"
               }

--- a/gcp-gitlab/terraform/gcp/kms.tf
+++ b/gcp-gitlab/terraform/gcp/kms.tf
@@ -1,7 +1,7 @@
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${lower(var.uniquness)}"
+  keyring  = "vault-${local.cluster_name}-${lower(var.uniqueness)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-gitlab/terraform/gcp/kms.tf
+++ b/gcp-gitlab/terraform/gcp/kms.tf
@@ -1,20 +1,7 @@
-resource "random_string" "uniqueness" {
-  length           = 5
-  special          = false
-  lower            = true
-
-  lifecycle {
-    ignore_changes = [
-      length,
-      lower,
-    ]
-  }
-}
-
 module "vault_keys" {
   source = "./modules/kms"
 
-  keyring  = "vault-${local.cluster_name}-${random_string.uniqueness.result}"
+  keyring  = "vault-${local.cluster_name}-${lower(var.uniquness)}"
   keys     = ["vault-unseal", "vault-encrypt"]
   location = "global"
   project  = var.project

--- a/gcp-gitlab/terraform/gcp/storage.tf
+++ b/gcp-gitlab/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${random_string.uniqueness.result}"
+  bucket_name   = "vault-data-${local.cluster_name}-${lower(var.uniquness)}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-gitlab/terraform/gcp/storage.tf
+++ b/gcp-gitlab/terraform/gcp/storage.tf
@@ -1,7 +1,7 @@
 module "vault_data_bucket" {
   source = "./modules/storage_bucket"
 
-  bucket_name   = "vault-data-${local.cluster_name}-${lower(var.uniquness)}"
+  bucket_name   = "vault-data-${local.cluster_name}-${lower(var.uniqueness)}"
   force_destroy = var.force_destroy
   # https://cloud.google.com/storage/docs/locations#location-dr
   # https://cloud.google.com/storage/docs/key-terms#geo-redundant

--- a/gcp-gitlab/terraform/gcp/terraform.tfvars
+++ b/gcp-gitlab/terraform/gcp/terraform.tfvars
@@ -1,0 +1,2 @@
+force_destroy = <TERRAFORM_FORCE_DESTROY>
+uniqueness = "<GOOGLE_UNIQUENESS>"

--- a/gcp-gitlab/terraform/gcp/variables.tf
+++ b/gcp-gitlab/terraform/gcp/variables.tf
@@ -29,3 +29,8 @@ variable "force_destroy" {
 
   default = "false"
 }
+
+variable "uniqueness" {
+  description = "variable used to acoid collision amongst immutable resource names"
+  type        = string
+}


### PR DESCRIPTION
had a feeling using terraform for the random string would bite me. I need to use it in detokenization so vault can unseal (needs the keyring name which I made unique) so I'll have to generate the uniqueness in code 