### PR TITLE
fix: sync gcp-github metaphor image template values with aws-github

### DIFF
--- a/gcp-github/cluster-types/mgmt/components/development/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/development/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/metaphor/charts/metaphor/values.yaml
+++ b/metaphor/charts/metaphor/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: <CONTAINER_REGISTRY_URL>
+  repository: <CONTAINER_REGISTRY_URL>/metaphor
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
This might be something to consider addressing in association with the issue raised by https://github.com/kubefirst/kubefirst/pull/1774.

In https://github.com/kubefirst/gitops-template/commit/cafa37eb633713ce3d38b4aaf82e915d418f0997, the [aws-github metaphor chart values](https://github.com/kubefirst/gitops-template/blob/cafa37eb633713ce3d38b4aaf82e915d418f0997/aws-github/cluster-types/mgmt/components/development/metaphor/values.yaml#L3) were transitioned from

```yaml
metaphor:
  image:
    repository: ghcr.io/<GITHUB_OWNER>/metaphor
```

to 

```yaml
metaphor:
  image:
    repository: <CONTAINER_REGISTRY_URL>/metaphor
```

which ensured the package name was appended and provided the opportunity to support artifact registries other than ghcr. The gcp provider didn't receive this update, perhaps because `--gar` support was not an initial goal, but it might be useful to abstract the FQIN in preparation for support of `--gar` by analogy to `--ecr` unless the plan is to create separate subdirectories for every `provider-registry` pairing.