### PR TITLE
feat: default to private nodes on gcp gke

### DIFF
--- a/gcp-github/terraform/gcp/gke/main.tf
+++ b/gcp-github/terraform/gcp/gke/main.tf
@@ -9,12 +9,16 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source = "terraform-google-modules/kubernetes-engine/google"
+  source = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
 
   name            = var.cluster_name
   project_id      = var.project
   region          = var.gcp_region
   release_channel = "STABLE"
+
+  // External availability
+  enable_private_endpoint = false
+  enable_private_nodes    = true
 
   // Service Account
   create_service_account = true

--- a/gcp-github/terraform/gcp/gke/main.tf
+++ b/gcp-github/terraform/gcp/gke/main.tf
@@ -69,6 +69,7 @@ module "gke" {
     all = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
     ]
   }
 

--- a/gcp-github/terraform/gcp/gke/nat.tf
+++ b/gcp-github/terraform/gcp/gke/nat.tf
@@ -1,0 +1,16 @@
+resource "google_compute_router" "router" {
+  name    = "kubefirst-cloud-router"
+  project = var.project
+  network = var.network
+  region  = var.gcp_region
+}
+
+module "cloud-nat" {
+  name                               = "kubefirst-nat-config"
+  source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "~> 4.0"
+  project_id                         = var.project
+  region                             = var.gcp_region
+  router                             = google_compute_router.router.name
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}

--- a/gcp-github/terraform/gcp/gke/nat.tf
+++ b/gcp-github/terraform/gcp/gke/nat.tf
@@ -1,5 +1,5 @@
 resource "google_compute_router" "router" {
-  name    = "kubefirst-cloud-router"
+  name    = "gke-cloud-router-${local.cluster_name}"
   project = var.project
   network = var.network
   region  = var.gcp_region

--- a/gcp-github/terraform/gcp/gke/nat.tf
+++ b/gcp-github/terraform/gcp/gke/nat.tf
@@ -6,7 +6,7 @@ resource "google_compute_router" "router" {
 }
 
 module "cloud-nat" {
-  name                               = "kubefirst-nat-config"
+  name                               = "gke-nat-config-${local.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
   version                            = "~> 4.0"
   project_id                         = var.project

--- a/gcp-github/terraform/gcp/vpc.tf
+++ b/gcp-github/terraform/gcp/vpc.tf
@@ -11,7 +11,7 @@ module "vpc" {
       subnet_name           = "subnet-01-${local.cluster_name}"
       subnet_ip             = "10.10.10.0/24"
       subnet_region         = var.gcp_region
-      subnet_private_access = "false"
+      subnet_private_access = "true"
       subnet_flow_logs      = "true"
       description           = "This base subnet."
     },

--- a/gcp-gitlab/terraform/gcp/gke/main.tf
+++ b/gcp-gitlab/terraform/gcp/gke/main.tf
@@ -9,12 +9,16 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source = "terraform-google-modules/kubernetes-engine/google"
+  source = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
 
   name            = var.cluster_name
   project_id      = var.project
   region          = var.gcp_region
   release_channel = "STABLE"
+
+  // External availability
+  enable_private_endpoint = false
+  enable_private_nodes    = true
 
   // Service Account
   create_service_account = true

--- a/gcp-gitlab/terraform/gcp/gke/main.tf
+++ b/gcp-gitlab/terraform/gcp/gke/main.tf
@@ -69,6 +69,7 @@ module "gke" {
     all = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
     ]
   }
 

--- a/gcp-gitlab/terraform/gcp/gke/nat.tf
+++ b/gcp-gitlab/terraform/gcp/gke/nat.tf
@@ -1,0 +1,16 @@
+resource "google_compute_router" "router" {
+  name    = "kubefirst-cloud-router"
+  project = var.project
+  network = var.network
+  region  = var.gcp_region
+}
+
+module "cloud-nat" {
+  name                               = "kubefirst-nat-config"
+  source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "~> 4.0"
+  project_id                         = var.project
+  region                             = var.gcp_region
+  router                             = google_compute_router.router.name
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}

--- a/gcp-gitlab/terraform/gcp/gke/nat.tf
+++ b/gcp-gitlab/terraform/gcp/gke/nat.tf
@@ -1,5 +1,5 @@
 resource "google_compute_router" "router" {
-  name    = "kubefirst-cloud-router"
+  name    = "gke-cloud-router-${local.cluster_name}"
   project = var.project
   network = var.network
   region  = var.gcp_region

--- a/gcp-gitlab/terraform/gcp/gke/nat.tf
+++ b/gcp-gitlab/terraform/gcp/gke/nat.tf
@@ -6,7 +6,7 @@ resource "google_compute_router" "router" {
 }
 
 module "cloud-nat" {
-  name                               = "kubefirst-nat-config"
+  name                               = "gke-nat-config-${local.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
   version                            = "~> 4.0"
   project_id                         = var.project

--- a/gcp-gitlab/terraform/gcp/vpc.tf
+++ b/gcp-gitlab/terraform/gcp/vpc.tf
@@ -11,7 +11,7 @@ module "vpc" {
       subnet_name           = "subnet-01-${local.cluster_name}"
       subnet_ip             = "10.10.10.0/24"
       subnet_region         = var.gcp_region
-      subnet_private_access = "false"
+      subnet_private_access = "true"
       subnet_flow_logs      = "true"
       description           = "This base subnet."
     },


### PR DESCRIPTION
**Of note, this is tested 1x and with google dns**.

You can enable gke private nodes, while retaining a public endpoint
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/2f5a2769fada01333b178d0bc9ec1e8192535043/modules/private-cluster

```HCL
module "gke" {
  source                     = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
  enable_private_endpoint    = false
  enable_private_nodes       = true
```

This might be a workable and, at least slightly, more secure default near https://github.com/kubefirst/gitops-template/blob/ef737f88cf87216f05d8459da69d7d2d0f673b45/gcp-github/terraform/gcp/gke/main.tf#L12