### PR TITLE
fix: template metaphor image variables on gcp

### DIFF
--- a/gcp-github/cluster-types/mgmt/components/development/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/development/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/gcp-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -1,6 +1,6 @@
 metaphor:
   image:
-    repository: ghcr.io/<GITHUB_OWNER>/metaphor
+    repository: <CONTAINER_REGISTRY_URL>/metaphor
   imagePullSecrets:
   - name: docker-config
   ingress:

--- a/metaphor/charts/metaphor/values.yaml
+++ b/metaphor/charts/metaphor/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: <CONTAINER_REGISTRY_URL>
+  repository: <CONTAINER_REGISTRY_URL>/metaphor
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
- rebasing https://github.com/kubefirst/gitops-template/pull/549
  - the same logic applies from [the comment](https://github.com/kubefirst/gitops-template/pull/549#issue-1867737289).
- correlated with kubefirst/kubefirst#1774