### PR TITLE
docs: clarify why CoreDNS is commented for AWS

### DIFF
--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -44,6 +44,7 @@ module "eks" {
   create_kms_key                 = false
   cluster_encryption_config      = {}
   cluster_addons = {
+    # AWS launch CoreDNS itself with their add-on https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
     # coredns = {
     #   most_recent = true
     #   resolve_conflicts = "OVERWRITE"

--- a/aws-gitlab/terraform/aws/eks/main.tf
+++ b/aws-gitlab/terraform/aws/eks/main.tf
@@ -44,6 +44,7 @@ module "eks" {
   create_kms_key                 = false
   cluster_encryption_config      = {}
   cluster_addons = {
+    # AWS launch CoreDNS itself with their add-on https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
     # coredns = {
     #   most_recent = true
     #   resolve_conflicts = "OVERWRITE"


### PR DESCRIPTION
someone asked in the community, so I think it would prevent further misunderstanding