### PR TITLE
Fix: Solves broken GCP Github Terraform Install Process 

### DIFF
--- a/google-github/terraform/google/gke/nat.tf
+++ b/google-github/terraform/google/gke/nat.tf
@@ -8,7 +8,7 @@ resource "google_compute_router" "router" {
 module "cloud-nat" {
   name                               = "gke-nat-config-${var.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
-  version                            = "~> 4.0"
+  version                            = "~> 5.0"
   project_id                         = var.project
   region                             = var.google_region
   router                             = google_compute_router.router.name


### PR DESCRIPTION
Updates nat.tf to 5.0, which was the cause of a hang up in the Terraform installation process for GCP/Google Install Configurations. 

Fix was suggested in kubefirst slack by `@DrummyFloyd`: [here](https://kubefirst.slack.com/archives/C03U34WJ7FW/p1699133610938569?thread_ts=1699123349.084229&cid=C03U34WJ7FW) 

## Before (using nat.tf with version "~> 4.0"
![Screenshot 2023-11-04 at 14 40 06](https://github.com/kubefirst/gitops-template/assets/10480589/d9bf284a-618c-4492-8dca-8ecbfa9a59fe)
![Screenshot 2023-11-04 at 14 41 46](https://github.com/kubefirst/gitops-template/assets/10480589/9999fbb1-e05f-4d4e-bd1d-d40a59fe95b9)

## After (using nat.tf with version "~> 5.0"
<img width="874" alt="Screenshot 2023-11-05 at 09 39 59" src="https://github.com/kubefirst/gitops-template/assets/10480589/0a5d3ece-f6fd-433b-8638-bbdcb7a43dfd">


