### PR TITLE
Preventing the miss-interpretation of the appVersion

### DIFF
--- a/aws-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/aws-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/aws-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/aws-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/civo-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/civo-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/civo-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/civo-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/digitalocean-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/digitalocean-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/digitalocean-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/google-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/google-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/google-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/google-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/k3d-github/cluster-types/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/k3d-gitlab/cluster-types/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/vultr-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/vultr-github/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:

--- a/vultr-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
+++ b/vultr-gitlab/templates/mgmt/components/argo-workflows/cwfts/cwft-helm.yaml
@@ -43,7 +43,7 @@ spec:
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to version: ${NEW_CHART_VERSION}"
         sed -i "s/version:.*/version: ${NEW_CHART_VERSION}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "setting ./{{inputs.parameters.chartDir}}/Chart.yaml to appVersion: {{inputs.parameters.shortSha}}"
-        sed -i "s/appVersion:.*/appVersion: {{inputs.parameters.shortSha}}/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
+        sed -i "s/appVersion:.*/appVersion: '{{inputs.parameters.shortSha}}'/g" /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
         echo "adjusted chart:"
         cat /src/{{inputs.parameters.appName}}/{{inputs.parameters.chartDir}}/Chart.yaml
     outputs:


### PR DESCRIPTION
If the shortSha contains an 'e' on the third to the last character, it was misinterpreted by the sed command hence writing an invalid version in the helm chart chart.yaml

For example a shortSha variable, holding a value of "6063e25", was misinterpreted as a numerical value in scientific notation by the system, generating an appVersion of "6.063e+28" instead of appVersion: "6063e25".

The fix is ensuring that shortSha is always treated as a string.