### PR TITLE
Fix: remove `clusters` subdirectory for crossplane

### DIFF
--- a/k3d-github/cluster-types/mgmt/crossplane.yaml
+++ b/k3d-github/cluster-types/mgmt/crossplane.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: <GITOPS_REPO_URL>
-    path: registry/clusters/<CLUSTER_NAME>/components/crossplane
+    path: registry/<CLUSTER_NAME>/components/crossplane
     targetRevision: HEAD
   destination:
     name: in-cluster

--- a/k3d-gitlab/cluster-types/mgmt/crossplane.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/crossplane.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: <GITOPS_REPO_URL>
-    path: registry/clusters/<CLUSTER_NAME>/components/crossplane
+    path: registry/<CLUSTER_NAME>/components/crossplane
     targetRevision: HEAD
   destination:
     name: in-cluster


### PR DESCRIPTION
Love seeing Crossplane in k3d by default! Unfortunately since we don't yet have cluster management in local the subdirectory of `clusters` breaks things.

The error I saw in Argo was:
```
rpc error: code = Unknown desc = registry/clusters/kubefirst/components/crossplane: app path does not exist
```

Screenshots:
<img width="1341" alt="image" src="https://github.com/kubefirst/gitops-template/assets/1557346/c15d8585-d8fd-4164-84b5-a63bd109d4c9">
<img width="1083" alt="image" src="https://github.com/kubefirst/gitops-template/assets/1557346/45cd1da3-f681-42b1-8fd1-f8ee7740537d">
<img width="998" alt="image" src="https://github.com/kubefirst/gitops-template/assets/1557346/532b6d7c-cebf-4a1a-9f53-93ed743f6343">
