### PR TITLE
feat(terraform): various terraform tweaks

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,10 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.3.8
+          
       - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check
+        run: make fmt

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/.terraform.lock.hcl
 **/terraform.tfstate
 */**/terraform.tfstate.backup
+.plugin-cache/*
 .vscode
 .DS_Store
 deprecated-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+default: help
+
+.PHONY: help
+help: ## print targets and their descrptions
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: fmt
+fmt: ## terraform fmt
+	terraform fmt -recursive -write .
+
+.PHONY: validate
+validate: ## terraform validate
+	@for dir in $(shell find . -name "*.tf" -not -path "*.terraform*" -printf '%h ' | uniq); do \
+		echo "====> $$dir"; \
+		terraform -chdir=$$dir init -backend=false || exit 1; \
+		terraform -chdir=$$dir validate || exit 1; \
+	done

--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -75,7 +75,7 @@ module "eks" {
   control_plane_subnet_ids = module.vpc.intra_subnets
 
   manage_aws_auth_configmap = true
-  
+
   aws_auth_roles = [
     # managed node group is automatically added to the configmap
     {
@@ -374,7 +374,7 @@ module "argocd" {
     argocd = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
   }
   assume_role_condition_test = "StringLike"
-  allow_self_assume_role = true
+  allow_self_assume_role     = true
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
@@ -605,7 +605,7 @@ module "kubefirst_api" {
     kubefirst = "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
   }
   assume_role_condition_test = "StringLike"
-  allow_self_assume_role = true
+  allow_self_assume_role     = true
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn

--- a/aws-github/terraform/aws/eks/outputs.tf
+++ b/aws-github/terraform/aws/eks/outputs.tf
@@ -2,6 +2,6 @@ output "node_iam_role_name" {
   value = module.eks.eks_managed_node_groups.default_node_group.iam_role_name
 }
 
-output "external_dns_policy_arn"{
+output "external_dns_policy_arn" {
   value = aws_iam_policy.external_dns.arn
 }

--- a/aws-github/terraform/aws/modules/bootstrap/bootstrap.tf
+++ b/aws-github/terraform/aws/modules/bootstrap/bootstrap.tf
@@ -29,7 +29,7 @@ data "vault_generic_secret" "external_dns" {
 
 resource "kubernetes_secret_v1" "external_dns" {
   metadata {
-    name = "external-dns-secrets"
+    name      = "external-dns-secrets"
     namespace = kubernetes_namespace_v1.external_dns.metadata.0.name
   }
   data = {

--- a/aws-github/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-github/terraform/aws/modules/workload-cluster/main.tf
@@ -3,8 +3,8 @@ data "aws_availability_zones" "available" {}
 
 locals {
   cluster_version = "1.26"
-  vpc_cidr = "10.0.0.0/16"
-  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+  vpc_cidr        = "10.0.0.0/16"
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
   tags = {
     kubefirst = "true"
   }
@@ -18,14 +18,14 @@ module "iam_node_group_role" {
 
   create_role = true
 
-  role_name_prefix  = "${var.cluster_name}-node-group"
+  role_name_prefix = "${var.cluster_name}-node-group"
 
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
   ]
-   number_of_custom_role_policy_arns = 3
+  number_of_custom_role_policy_arns = 3
 }
 
 module "eks" {
@@ -71,7 +71,7 @@ module "eks" {
   control_plane_subnet_ids = module.vpc.intra_subnets
 
   manage_aws_auth_configmap = false
-  
+
   # aws_auth_roles = [
   #   # managed node group is automatically added to the configmap
   #   {
@@ -437,11 +437,11 @@ resource "vault_generic_secret" "clusters" {
 
   data_json = jsonencode(
     {
-      cluster_ca_certificate  = module.eks.cluster_certificate_authority_data
-      host                    = module.eks.cluster_endpoint
-      cluster_name            = var.cluster_name
-      environment             = var.cluster_name
-      argocd_role_arn         = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
+      cluster_ca_certificate = module.eks.cluster_certificate_authority_data
+      host                   = module.eks.cluster_endpoint
+      cluster_name           = var.cluster_name
+      environment            = var.cluster_name
+      argocd_role_arn        = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
     }
   )
 }

--- a/aws-github/terraform/users/modules/user/main.tf
+++ b/aws-github/terraform/users/modules/user/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once
@@ -109,7 +109,7 @@ variable "team_id" {
 }
 
 resource "github_team_membership" "team_membership" {
-  count = var.user_disabled == true ? 0 : 1
+  count    = var.user_disabled == true ? 0 : 1
   team_id  = var.team_id
   username = var.github_username
 }

--- a/aws-github/terraform/vault/oidc-clients.tf
+++ b/aws-github/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/aws-github/terraform/vault/secrets.tf
+++ b/aws-github/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -13,50 +13,43 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane_secrets" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
-      VAULT_ADDR            = "http://vault.vault.svc.cluster.local:8200"
-      VAULT_TOKEN           = var.vault_token
-      password              = var.github_token
-      username              = "<GITHUB_USER>"
+      VAULT_ADDR  = "http://vault.vault.svc.cluster.local:8200"
+      VAULT_TOKEN = var.vault_token
+      password    = var.github_token
+      username    = "<GITHUB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "regsitry_auth" {
-  path = "secret/registry-auth"
+  path = "${vault_mount.secret.path}/registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
+
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -65,12 +58,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -79,12 +70,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -93,12 +82,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -108,12 +95,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   # variables that appear duplicated are for circumstances where both terraform
   # and seperately the terraform provider each need the value
@@ -142,6 +127,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       VAULT_TOKEN                         = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/aws-github/terraform/vault/secrets.tf
+++ b/aws-github/terraform/vault/secrets.tf
@@ -48,40 +48,18 @@ resource "vault_generic_secret" "regsitry_auth" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/aws-gitlab/terraform/aws/eks/main.tf
+++ b/aws-gitlab/terraform/aws/eks/main.tf
@@ -87,7 +87,7 @@ module "eks" {
     # See https://github.com/aws/containers-roadmap/issues/1666 for more context
     iam_role_attach_cni_policy = true
   }
-  iam_role_additional_policies =  {
+  iam_role_additional_policies = {
 
   }
 

--- a/aws-gitlab/terraform/aws/eks/outputs.tf
+++ b/aws-gitlab/terraform/aws/eks/outputs.tf
@@ -2,6 +2,6 @@ output "node_iam_role_name" {
   value = module.eks.eks_managed_node_groups.default_node_group.iam_role_name
 }
 
-output "external_dns_policy_arn"{
+output "external_dns_policy_arn" {
   value = aws_iam_policy.external_dns.arn
 }

--- a/aws-gitlab/terraform/users/modules/user/main.tf
+++ b/aws-gitlab/terraform/users/modules/user/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -50,7 +50,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/aws-gitlab/terraform/vault/oidc-clients.tf
+++ b/aws-gitlab/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/aws-gitlab/terraform/vault/secrets.tf
+++ b/aws-gitlab/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -13,52 +13,44 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane_secrets" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
-      VAULT_ADDR            = "http://vault.vault.svc.cluster.local:8200"
-      VAULT_TOKEN           = var.vault_token
-      password              = var.gitlab_token
-      username              = "<GITLAB_USER>"
+      VAULT_ADDR  = "http://vault.vault.svc.cluster.local:8200"
+      VAULT_TOKEN = var.vault_token
+      password    = var.gitlab_token
+      username    = "<GITLAB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -67,12 +59,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -81,12 +71,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -95,12 +83,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -110,8 +96,6 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.gitlab_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -119,18 +103,17 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path       = "secret/gitlab-runner"
-  data_json  = <<EOT
+  path      = "${vault_mount.secret.path}/gitlab-runner"
+  data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -157,6 +140,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       VAULT_TOKEN                         = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/aws-gitlab/terraform/vault/secrets.tf
+++ b/aws-gitlab/terraform/vault/secrets.tf
@@ -49,40 +49,18 @@ resource "vault_generic_secret" "container_registry_auth" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/aws-gitlab/terraform/vault/variables.tf
+++ b/aws-gitlab/terraform/vault/variables.tf
@@ -42,5 +42,5 @@ variable "vault_token" {
 
 variable "container_registry_auth" {
   default = ""
-  type = string
+  type    = string
 }

--- a/civo-github/terraform/civo/main.tf
+++ b/civo-github/terraform/civo/main.tf
@@ -16,11 +16,11 @@ terraform {
       source = "civo/civo"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "2.23.0"
     }
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "3.19.0"
     }
   }
@@ -30,7 +30,7 @@ provider "civo" {
 }
 
 locals {
-  cluster_name = "<CLUSTER_NAME>"
+  cluster_name         = "<CLUSTER_NAME>"
   kube_config_filename = "../../../kubeconfig"
 }
 

--- a/civo-github/terraform/users/modules/user/github/main.tf
+++ b/civo-github/terraform/users/modules/user/github/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/civo-github/terraform/vault/oidc-clients.tf
+++ b/civo-github/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/civo-github/terraform/vault/secrets.tf
+++ b/civo-github/terraform/vault/secrets.tf
@@ -64,40 +64,18 @@ resource "vault_generic_secret" "regsitry_auth" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/civo-github/terraform/vault/secrets.tf
+++ b/civo-github/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -15,12 +15,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "civo_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -28,12 +26,10 @@ resource "vault_generic_secret" "civo_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -46,36 +42,30 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITHUB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "regsitry_auth" {
-  path = "secret/registry-auth"
+  path = "${vault_mount.secret.path}/registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -84,12 +74,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -98,12 +86,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -112,12 +98,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -129,12 +113,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "cloudflare" {
-  path = "secret/cloudflare"
+  path = "${vault_mount.secret.path}/cloudflare"
 
   data_json = jsonencode(
     {
@@ -143,12 +125,10 @@ resource "vault_generic_secret" "cloudflare" {
       cloudflare-token  = var.cloudflare_api_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -179,6 +159,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/civo-github/terraform/vault/variables.tf
+++ b/civo-github/terraform/vault/variables.tf
@@ -7,12 +7,12 @@ variable "b64_docker_auth" {
 }
 
 variable "cloudflare_origin_ca_api_key" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cloudflare_api_key" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/civo-gitlab/terraform/users/modules/user/main.tf
+++ b/civo-gitlab/terraform/users/modules/user/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -50,7 +50,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/civo-gitlab/terraform/vault/oidc-clients.tf
+++ b/civo-gitlab/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/civo-gitlab/terraform/vault/secrets.tf
+++ b/civo-gitlab/terraform/vault/secrets.tf
@@ -49,41 +49,18 @@ resource "vault_generic_secret" "docker_config" {
   )
 }
 
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/civo-gitlab/terraform/vault/secrets.tf
+++ b/civo-gitlab/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -15,24 +15,20 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "civo_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -40,50 +36,46 @@ resource "vault_generic_secret" "civo_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "development secret 1",
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "staging secret 1",
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -92,12 +84,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -109,7 +99,6 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.gitlab_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -117,18 +106,17 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path       = "secret/gitlab-runner"
-  data_json  = <<EOT
+  path      = "${vault_mount.secret.path}/gitlab-runner"
+  data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -159,11 +147,10 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -176,6 +163,4 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITLAB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/digitalocean-github/terraform/digitalocean/modules/workload-cluster/main.tf
+++ b/digitalocean-github/terraform/digitalocean/modules/workload-cluster/main.tf
@@ -35,7 +35,7 @@ resource "vault_generic_secret" "clusters" {
       argocd_manager_sa_token = kubernetes_secret_v1.argocd_manager.data.token
     }
   )
-  depends_on = [ digitalocean_kubernetes_cluster.cluster ]
+  depends_on = [digitalocean_kubernetes_cluster.cluster]
 }
 
 provider "kubernetes" {

--- a/digitalocean-github/terraform/digitalocean/modules/workload-cluster/variables.tf
+++ b/digitalocean-github/terraform/digitalocean/modules/workload-cluster/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_region" {
 }
 
 variable "environment" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/digitalocean-github/terraform/digitalocean/variables.tf
+++ b/digitalocean-github/terraform/digitalocean/variables.tf
@@ -1,4 +1,4 @@
-variable region {
+variable "region" {
   type        = string
   default     = "<CLOUD_REGION>"
   description = "region to create cluster in"

--- a/digitalocean-github/terraform/github/repos.tf
+++ b/digitalocean-github/terraform/github/repos.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/github/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-github/terraform/users/modules/user/github/main.tf
+++ b/digitalocean-github/terraform/users/modules/user/github/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once
@@ -109,7 +109,7 @@ variable "team_id" {
 }
 
 resource "github_team_membership" "team_membership" {
-  count = var.user_disabled == true ? 0 : 1
+  count    = var.user_disabled == true ? 0 : 1
   team_id  = var.team_id
   username = var.github_username
 }

--- a/digitalocean-github/terraform/users/users.tf
+++ b/digitalocean-github/terraform/users/users.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/users/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-github/terraform/vault/main.tf
+++ b/digitalocean-github/terraform/vault/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/vault/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-github/terraform/vault/oidc-clients.tf
+++ b/digitalocean-github/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/digitalocean-github/terraform/vault/secrets.tf
+++ b/digitalocean-github/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -15,12 +15,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -33,12 +31,10 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITHUB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "digitalocean_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -46,36 +42,30 @@ resource "vault_generic_secret" "digitalocean_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "registry_auth" {
-  path = "secret/registry-auth"
+  path = "${vault_mount.secret.path}/registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -84,12 +74,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -98,12 +86,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -112,12 +98,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -129,12 +113,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -163,6 +145,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/digitalocean-github/terraform/vault/secrets.tf
+++ b/digitalocean-github/terraform/vault/secrets.tf
@@ -64,40 +64,18 @@ resource "vault_generic_secret" "registry_auth" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/digitalocean-github/terraform/vault/variables.tf
+++ b/digitalocean-github/terraform/vault/variables.tf
@@ -4,7 +4,7 @@ locals {
 
 variable "<EXTERNAL_DNS_PROVIDER_NAME>_secret" {
   default = ""
-  type = string
+  type    = string
 }
 
 variable "b64_docker_auth" {

--- a/digitalocean-gitlab/terraform/digitalocean/main.tf
+++ b/digitalocean-gitlab/terraform/digitalocean/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/digitalocean/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-gitlab/terraform/digitalocean/modules/workload-cluster/main.tf
+++ b/digitalocean-gitlab/terraform/digitalocean/modules/workload-cluster/main.tf
@@ -35,7 +35,7 @@ resource "vault_generic_secret" "clusters" {
       argocd_manager_sa_token = kubernetes_secret_v1.argocd_manager.data.token
     }
   )
-  depends_on = [ digitalocean_kubernetes_cluster.cluster ]
+  depends_on = [digitalocean_kubernetes_cluster.cluster]
 }
 
 provider "kubernetes" {

--- a/digitalocean-gitlab/terraform/digitalocean/modules/workload-cluster/variables.tf
+++ b/digitalocean-gitlab/terraform/digitalocean/modules/workload-cluster/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_region" {
 }
 
 variable "environment" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/digitalocean-gitlab/terraform/digitalocean/variables.tf
+++ b/digitalocean-gitlab/terraform/digitalocean/variables.tf
@@ -1,4 +1,4 @@
-variable region {
+variable "region" {
   type        = string
   default     = "<CLOUD_REGION>"
   description = "region to create cluster in"

--- a/digitalocean-gitlab/terraform/gitlab/main.tf
+++ b/digitalocean-gitlab/terraform/gitlab/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/gitlab/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-gitlab/terraform/users/modules/user/main.tf
+++ b/digitalocean-gitlab/terraform/users/modules/user/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -50,7 +50,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/digitalocean-gitlab/terraform/users/users.tf
+++ b/digitalocean-gitlab/terraform/users/users.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/users/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-gitlab/terraform/vault/main.tf
+++ b/digitalocean-gitlab/terraform/vault/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    endpoint ="nyc3.digitaloceanspaces.com"
+    endpoint = "nyc3.digitaloceanspaces.com"
     key      = "terraform/vault/terraform.tfstate"
     bucket   = "<KUBEFIRST_STATE_STORE_BUCKET>"
     // Don't change this.

--- a/digitalocean-gitlab/terraform/vault/oidc-clients.tf
+++ b/digitalocean-gitlab/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/digitalocean-gitlab/terraform/vault/secrets.tf
+++ b/digitalocean-gitlab/terraform/vault/secrets.tf
@@ -65,41 +65,18 @@ resource "vault_generic_secret" "docker_config" {
   )
 }
 
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/digitalocean-gitlab/terraform/vault/secrets.tf
+++ b/digitalocean-gitlab/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -15,12 +15,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -33,24 +31,20 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITLAB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "digitalocean_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -58,51 +52,46 @@ resource "vault_generic_secret" "digitalocean_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "development secret 1",
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "staging secret 1",
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -111,12 +100,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -128,7 +115,6 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.gitlab_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -136,18 +122,17 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path       = "secret/gitlab-runner"
-  data_json  = <<EOT
+  path      = "${vault_mount.secret.path}/gitlab-runner"
+  data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -178,5 +163,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }

--- a/digitalocean-gitlab/terraform/vault/variables.tf
+++ b/digitalocean-gitlab/terraform/vault/variables.tf
@@ -4,7 +4,7 @@ locals {
 
 variable "<EXTERNAL_DNS_PROVIDER_NAME>_secret" {
   default = ""
-  type = string
+  type    = string
 }
 
 variable "b64_docker_auth" {

--- a/google-github/terraform/google/gke.tf
+++ b/google-github/terraform/google/gke.tf
@@ -1,9 +1,9 @@
 module "gke" {
   source = "./gke"
 
-  cluster_name = local.cluster_name
-  google_region   = var.google_region
-  project      = var.project
+  cluster_name  = local.cluster_name
+  google_region = var.google_region
+  project       = var.project
 
   network    = module.vpc.network_name
   subnetwork = lookup(module.vpc.subnets, "${var.google_region}/subnet-01-${local.cluster_name}").name

--- a/google-github/terraform/google/gke/main.tf
+++ b/google-github/terraform/google/gke/main.tf
@@ -41,7 +41,7 @@ module "gke" {
   // Node Pools
   node_pools = [
     {
-      name         = "kubefirst"
+      name      = "kubefirst"
       node_type = var.instance_type
 
       // Autoscaling

--- a/google-github/terraform/google/terraform.tfvars
+++ b/google-github/terraform/google/terraform.tfvars
@@ -1,2 +1,2 @@
 force_destroy = "<TERRAFORM_FORCE_DESTROY>"
-uniqueness = "<GOOGLE_UNIQUENESS>"
+uniqueness    = "<GOOGLE_UNIQUENESS>"

--- a/google-github/terraform/users/modules/user/github/main.tf
+++ b/google-github/terraform/users/modules/user/github/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once
@@ -111,7 +111,7 @@ variable "team_id" {
 }
 
 resource "github_team_membership" "team_membership" {
-  count = var.user_disabled == true ? 0 : 1
+  count    = var.user_disabled == true ? 0 : 1
   team_id  = var.team_id
   username = var.github_username
 }

--- a/google-github/terraform/vault/oidc-clients.tf
+++ b/google-github/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/google-github/terraform/vault/secrets.tf
+++ b/google-github/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -13,12 +13,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane_secrets" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -34,31 +32,27 @@ resource "vault_generic_secret" "crossplane_secrets" {
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/registry-auth"
+  path = "${vault_mount.secret.path}/registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -67,12 +61,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -81,12 +73,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -95,12 +85,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -110,12 +98,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -141,5 +127,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
     }
   )
 
-  depends_on = [vault_mount.secret]
 }

--- a/google-github/terraform/vault/secrets.tf
+++ b/google-github/terraform/vault/secrets.tf
@@ -51,40 +51,18 @@ resource "vault_generic_secret" "docker_config" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/google-gitlab/terraform/google/gke.tf
+++ b/google-gitlab/terraform/google/gke.tf
@@ -1,9 +1,9 @@
 module "gke" {
   source = "./gke"
 
-  cluster_name = local.cluster_name
-  google_region   = var.google_region
-  project      = var.project
+  cluster_name  = local.cluster_name
+  google_region = var.google_region
+  project       = var.project
 
   network    = module.vpc.network_name
   subnetwork = lookup(module.vpc.subnets, "${var.google_region}/subnet-01-${local.cluster_name}").name

--- a/google-gitlab/terraform/google/gke/main.tf
+++ b/google-gitlab/terraform/google/gke/main.tf
@@ -41,7 +41,7 @@ module "gke" {
   // Node Pools
   node_pools = [
     {
-      name         = "kubefirst"
+      name      = "kubefirst"
       node_type = var.instance_type
 
       // Autoscaling

--- a/google-gitlab/terraform/google/terraform.tfvars
+++ b/google-gitlab/terraform/google/terraform.tfvars
@@ -1,2 +1,2 @@
 force_destroy = "<TERRAFORM_FORCE_DESTROY>"
-uniqueness = "<GOOGLE_UNIQUENESS>"
+uniqueness    = "<GOOGLE_UNIQUENESS>"

--- a/google-gitlab/terraform/users/modules/user/main.tf
+++ b/google-gitlab/terraform/users/modules/user/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -50,7 +50,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/google-gitlab/terraform/vault/oidc-clients.tf
+++ b/google-gitlab/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/google-gitlab/terraform/vault/secrets.tf
+++ b/google-gitlab/terraform/vault/secrets.tf
@@ -49,40 +49,18 @@ resource "vault_generic_secret" "docker_config" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive. 
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/google-gitlab/terraform/vault/secrets.tf
+++ b/google-gitlab/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -13,12 +13,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane_secrets" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -29,35 +27,30 @@ resource "vault_generic_secret" "crossplane_secrets" {
       GOOGLE_APPLICATION_CREDENTIALS = "gcp-credentials"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive. 
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -66,12 +59,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -80,12 +71,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -94,12 +83,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -109,8 +96,6 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.gitlab_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -118,18 +103,17 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path       = "secret/gitlab-runner"
-  data_json  = <<EOT
+  path      = "${vault_mount.secret.path}/gitlab-runner"
+  data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -140,7 +124,7 @@ resource "vault_generic_secret" "atlantis_secrets" {
       ATLANTIS_GITLAB_WEBHOOK_SECRET      = var.atlantis_repo_webhook_secret,
       GITLAB_OWNER                        = "<GITLAB_OWNER>",
       GITLAB_TOKEN                        = var.gitlab_token,
-      GOOGLE_PROJECT                         = "<GOOGLE_PROJECT>"
+      GOOGLE_PROJECT                      = "<GOOGLE_PROJECT>"
       TF_VAR_atlantis_repo_webhook_secret = var.atlantis_repo_webhook_secret,
       TF_VAR_atlantis_repo_webhook_url    = var.atlantis_repo_webhook_url,
       TF_VAR_b64_docker_auth              = var.b64_docker_auth,
@@ -155,6 +139,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       VAULT_TOKEN                         = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/google-gitlab/terraform/vault/variables.tf
+++ b/google-gitlab/terraform/vault/variables.tf
@@ -4,7 +4,7 @@ locals {
 
 variable "<EXTERNAL_DNS_PROVIDER_NAME>_secret" {
   default = ""
-  type = string
+  type    = string
 }
 
 variable "b64_docker_auth" {

--- a/k3d-github/terraform/vault/oidc-clients.tf
+++ b/k3d-github/terraform/vault/oidc-clients.tf
@@ -10,7 +10,7 @@ module "argo" {
   redirect_uris = [
     "https://argo.<DOMAIN_NAME>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -25,7 +25,7 @@ module "argocd" {
   redirect_uris = [
     "https://argocd.<DOMAIN_NAME>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "gitlab" {
@@ -40,7 +40,7 @@ module "gitlab" {
   redirect_uris = [
     "https://gitlab.<DOMAIN_NAME>/users/auth/openid_connect/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.pat
 }
 
 module "console" {
@@ -55,7 +55,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/k3d-github/terraform/vault/secrets.tf
+++ b/k3d-github/terraform/vault/secrets.tf
@@ -87,40 +87,18 @@ resource "vault_generic_secret" "external_secrets_token" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/k3d-github/terraform/vault/secrets.tf
+++ b/k3d-github/terraform/vault/secrets.tf
@@ -1,17 +1,15 @@
 resource "vault_generic_secret" "atlantis_ngrok_secrets" {
-  path = "secret/atlantis-ngrok"
+  path = "${vault_mount.secret.path}/atlantis-ngrok"
 
   data_json = jsonencode(
     {
-      GIT_PROVIDER   = "<GIT_PROVIDER>",
-      GIT_OWNER      = "<GITHUB_OWNER>",
-      GIT_TOKEN      = var.github_token,
-      GIT_REPOSITORY = "gitops",
+      GIT_PROVIDER    = "<GIT_PROVIDER>",
+      GIT_OWNER       = "<GITHUB_OWNER>",
+      GIT_TOKEN       = var.github_token,
+      GIT_REPOSITORY  = "gitops",
       NGROK_AUTHTOKEN = var.ngrok_authtoken,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "random_password" "chartmuseum_password" {
@@ -21,7 +19,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -31,12 +29,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS       = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -48,36 +44,30 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITHUB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "regsitry_auth" {
-  path = "secret/registry-auth"
+  path = "${vault_mount.secret.path}/registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "minio_creds" {
-  path = "secret/minio"
+  path = "${vault_mount.secret.path}/minio"
 
   data_json = jsonencode(
     {
@@ -85,24 +75,20 @@ resource "vault_generic_secret" "minio_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "external_secrets_token" {
-  path = "secret/external-secrets-store"
+  path = "${vault_mount.secret.path}/external-secrets-store"
 
   data_json = jsonencode(
     {
       token = var.vault_token
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -111,12 +97,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -125,12 +109,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -139,12 +121,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -156,12 +136,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -187,6 +165,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       VAULT_TOKEN                         = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/k3d-gitlab/terraform/vault/oidc-clients.tf
+++ b/k3d-gitlab/terraform/vault/oidc-clients.tf
@@ -10,7 +10,7 @@ module "argo" {
   redirect_uris = [
     "https://argo.<DOMAIN_NAME>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -25,7 +25,7 @@ module "argocd" {
   redirect_uris = [
     "https://argocd.<DOMAIN_NAME>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "gitlab" {
@@ -40,7 +40,7 @@ module "gitlab" {
   redirect_uris = [
     "https://gitlab.<DOMAIN_NAME>/users/auth/openid_connect/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -55,7 +55,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/k3d-gitlab/terraform/vault/secrets.tf
+++ b/k3d-gitlab/terraform/vault/secrets.tf
@@ -72,54 +72,22 @@ resource "vault_generic_secret" "external_secrets_token" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
-
 data "gitlab_group" "owner" {
   group_id = var.owner_group_id
 }
 
-resource "vault_generic_secret" "gitlab_runner" {
-  path      = "${vault_mount.secret.path}/gitlab-runner"
-  data_json = <<EOT
-{
-  "RUNNER_TOKEN" : "",
-  "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/k3d-gitlab/terraform/vault/secrets.tf
+++ b/k3d-gitlab/terraform/vault/secrets.tf
@@ -1,17 +1,15 @@
 resource "vault_generic_secret" "atlantis_ngrok_secrets" {
-  path = "secret/atlantis-ngrok"
+  path = "${vault_mount.secret.path}/atlantis-ngrok"
 
   data_json = jsonencode(
     {
-      GIT_PROVIDER   = "<GIT_PROVIDER>",
-      GIT_OWNER      = "<GITHUB_OWNER>",
-      GIT_TOKEN      = var.gitlab_token,
-      GIT_REPOSITORY = "gitops",
+      GIT_PROVIDER    = "<GIT_PROVIDER>",
+      GIT_OWNER       = "<GITHUB_OWNER>",
+      GIT_TOKEN       = var.gitlab_token,
+      GIT_REPOSITORY  = "gitops",
       NGROK_AUTHTOKEN = var.ngrok_authtoken,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "random_password" "chartmuseum_password" {
@@ -21,7 +19,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -31,36 +29,30 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       BASIC_AUTH_PASS       = random_password.chartmuseum_password.result,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "minio_creds" {
-  path = "secret/minio"
+  path = "${vault_mount.secret.path}/minio"
 
   data_json = jsonencode(
     {
@@ -68,24 +60,20 @@ resource "vault_generic_secret" "minio_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "external_secrets_token" {
-  path = "secret/external-secrets-store"
+  path = "${vault_mount.secret.path}/external-secrets-store"
 
   data_json = jsonencode(
     {
       token = var.vault_token
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -94,8 +82,6 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -103,19 +89,17 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path      = "secret/gitlab-runner"
+  path      = "${vault_mount.secret.path}/gitlab-runner"
   data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -124,12 +108,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -138,12 +120,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -157,12 +137,10 @@ resource "vault_generic_secret" "ci_secrets" {
       password              = var.gitlab_token
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -190,12 +168,10 @@ resource "vault_generic_secret" "atlantis_secrets" {
       VAULT_TOKEN                         = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -207,6 +183,4 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITLAB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/vultr-github/terraform/users/modules/user/github/main.tf
+++ b/vultr-github/terraform/users/modules/user/github/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once
@@ -109,7 +109,7 @@ variable "team_id" {
 }
 
 resource "github_team_membership" "team_membership" {
-  count = var.user_disabled == true ? 0 : 1
+  count    = var.user_disabled == true ? 0 : 1
   team_id  = var.team_id
   username = var.github_username
 }

--- a/vultr-github/terraform/vault/oidc-clients.tf
+++ b/vultr-github/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/vultr-github/terraform/vault/secrets.tf
+++ b/vultr-github/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -16,11 +16,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
     }
   )
 
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -33,13 +32,11 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITHUB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "vultr_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -47,24 +44,20 @@ resource "vault_generic_secret" "vultr_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "ghcr.io" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -73,12 +66,10 @@ resource "vault_generic_secret" "development_metaphor" {
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -87,12 +78,10 @@ resource "vault_generic_secret" "staging_metaphor" {
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -101,12 +90,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -118,12 +105,10 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.github_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -152,6 +137,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }

--- a/vultr-github/terraform/vault/secrets.tf
+++ b/vultr-github/terraform/vault/secrets.tf
@@ -56,40 +56,18 @@ resource "vault_generic_secret" "docker_config" {
   )
 }
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {

--- a/vultr-gitlab/terraform/users/modules/user/main.tf
+++ b/vultr-gitlab/terraform/users/modules/user/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -50,7 +50,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/vultr-gitlab/terraform/vault/oidc-clients.tf
+++ b/vultr-gitlab/terraform/vault/oidc-clients.tf
@@ -11,7 +11,7 @@ module "argo" {
   redirect_uris = [
     "<ARGO_WORKFLOWS_INGRESS_URL>/oauth2/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "argocd" {
@@ -27,7 +27,7 @@ module "argocd" {
   redirect_uris = [
     "<ARGOCD_INGRESS_URL>/auth/callback",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 module "console" {
@@ -43,7 +43,7 @@ module "console" {
   redirect_uris = [
     "https://kubefirst.<DOMAIN_NAME>/api/auth/callback/vault",
   ]
-  secret_mount_path = "secret"
+  secret_mount_path = vault_mount.secret.path
 }
 
 # todo kubectl-oidc

--- a/vultr-gitlab/terraform/vault/secrets.tf
+++ b/vultr-gitlab/terraform/vault/secrets.tf
@@ -66,40 +66,18 @@ resource "vault_generic_secret" "docker_config" {
 }
 
 
-resource "vault_generic_secret" "development_metaphor" {
-  path = "${vault_mount.secret.path}/development/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "development secret 1",
-  "SECRET_TWO" : "development secret 2"
-}
-EOT
-}
+resource "vault_generic_secret" "metaphor" {
+  for_each = toset(["development", "staging", "production"])
 
-resource "vault_generic_secret" "staging_metaphor" {
-  path = "${vault_mount.secret.path}/staging/metaphor"
+  path = "${vault_mount.secret.path}/${each.key}/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "staging secret 1",
-  "SECRET_TWO" : "staging secret 2"
-}
-EOT
-}
-
-resource "vault_generic_secret" "production_metaphor" {
-  path = "${vault_mount.secret.path}/production/metaphor"
-  # note: these secrets are not actually sensitive.
-  # do not hardcode passwords in git under normal circumstances.
-  data_json = <<EOT
-{
-  "SECRET_ONE" : "production secret 1",
-  "SECRET_TWO" : "production secret 2"
-}
-EOT
+  data_json = jsonencode(
+    {
+      SECRET_ONE = "${each.key} secret 1"
+      SECRET_TWO = "${each.key} secret 2"
+    }
+  )
 }
 
 resource "vault_generic_secret" "ci_secrets" {
@@ -124,12 +102,12 @@ data "gitlab_group" "owner" {
 resource "vault_generic_secret" "gitlab_runner" {
   path = "${vault_mount.secret.path}/gitlab-runner"
 
-  data_json = <<EOT
-{
-  "RUNNER_TOKEN" : "",
-  "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
-}
-EOT
+  data_json = jsonencode(
+    {
+      "RUNNER_TOKEN"              = "",
+      "RUNNER_REGISTRATION_TOKEN" = data.gitlab_group.owner.runners_token
+    }
+  )
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {

--- a/vultr-gitlab/terraform/vault/secrets.tf
+++ b/vultr-gitlab/terraform/vault/secrets.tf
@@ -5,7 +5,7 @@ resource "random_password" "chartmuseum_password" {
 }
 
 resource "vault_generic_secret" "chartmuseum_secrets" {
-  path = "secret/chartmuseum"
+  path = "${vault_mount.secret.path}/secret/chartmuseum"
 
   data_json = jsonencode(
     {
@@ -15,12 +15,10 @@ resource "vault_generic_secret" "chartmuseum_secrets" {
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "crossplane" {
-  path = "secret/crossplane"
+  path = "${vault_mount.secret.path}/crossplane"
 
   data_json = jsonencode(
     {
@@ -33,24 +31,20 @@ resource "vault_generic_secret" "crossplane" {
       username              = "<GITLAB_USER>"
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "container_registry_auth" {
-  path = "secret/deploy-tokens/container-registry-auth"
+  path = "${vault_mount.secret.path}/deploy-tokens/container-registry-auth"
 
   data_json = jsonencode(
     {
       auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "vultr_creds" {
-  path = "secret/argo"
+  path = "${vault_mount.secret.path}/argo"
 
   data_json = jsonencode(
     {
@@ -58,51 +52,46 @@ resource "vault_generic_secret" "vultr_creds" {
       secretkey = var.aws_secret_access_key,
     }
   )
-
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "docker_config" {
-  path = "secret/dockerconfigjson"
+  path = "${vault_mount.secret.path}/dockerconfigjson"
 
   data_json = jsonencode(
     {
       dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 
 resource "vault_generic_secret" "development_metaphor" {
-  path = "secret/development/metaphor"
+  path = "${vault_mount.secret.path}/development/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "development secret 1",
   "SECRET_TWO" : "development secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "staging_metaphor" {
-  path = "secret/staging/metaphor"
+  path = "${vault_mount.secret.path}/staging/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
-  data_json  = <<EOT
+  data_json = <<EOT
 {
   "SECRET_ONE" : "staging secret 1",
   "SECRET_TWO" : "staging secret 2"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "production_metaphor" {
-  path = "secret/production/metaphor"
+  path = "${vault_mount.secret.path}/production/metaphor"
   # note: these secrets are not actually sensitive.
   # do not hardcode passwords in git under normal circumstances.
   data_json = <<EOT
@@ -111,12 +100,10 @@ resource "vault_generic_secret" "production_metaphor" {
   "SECRET_TWO" : "production secret 2"
 }
 EOT
-
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "ci_secrets" {
-  path = "secret/ci-secrets"
+  path = "${vault_mount.secret.path}/ci-secrets"
 
   data_json = jsonencode(
     {
@@ -128,7 +115,6 @@ resource "vault_generic_secret" "ci_secrets" {
       PERSONAL_ACCESS_TOKEN = var.gitlab_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }
 
 data "gitlab_group" "owner" {
@@ -136,18 +122,18 @@ data "gitlab_group" "owner" {
 }
 
 resource "vault_generic_secret" "gitlab_runner" {
-  path       = "secret/gitlab-runner"
-  data_json  = <<EOT
+  path = "${vault_mount.secret.path}/gitlab-runner"
+
+  data_json = <<EOT
 {
   "RUNNER_TOKEN" : "",
   "RUNNER_REGISTRATION_TOKEN" : "${data.gitlab_group.owner.runners_token}"
 }
 EOT
-  depends_on = [vault_mount.secret]
 }
 
 resource "vault_generic_secret" "atlantis_secrets" {
-  path = "secret/atlantis"
+  path = "${vault_mount.secret.path}/atlantis"
 
   data_json = jsonencode(
     {
@@ -163,8 +149,8 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_b64_docker_auth              = var.b64_docker_auth,
       TF_VAR_aws_access_key_id            = var.aws_access_key_id,
       TF_VAR_aws_secret_access_key        = var.aws_secret_access_key,
-      VULTR_API_KEY                         = var.vultr_api_key,
-      TF_VAR_vultr_api_key                  = var.vultr_api_key,
+      VULTR_API_KEY                       = var.vultr_api_key,
+      TF_VAR_vultr_api_key                = var.vultr_api_key,
       GITLAB_OWNER                        = "<GITLAB_OWNER>",
       GITLAB_TOKEN                        = var.gitlab_token,
       TF_VAR_gitlab_token                 = var.gitlab_token,
@@ -178,5 +164,4 @@ resource "vault_generic_secret" "atlantis_secrets" {
       TF_VAR_vault_token                  = var.vault_token,
     }
   )
-  depends_on = [vault_mount.secret]
 }


### PR DESCRIPTION
* avoided `depends_on` in all vault modules 
* run `terraform format` for all terraform dirs.  
* added a `Makefile` with `fmt` and `validate` target to perform these options conviently locally ( `make validate` catched some errors and warning that we might wanna fix in another PR.)
* Added `terraform format` recursive option in CI.
* metaphore secrets are now created using a single `vault_generic_secret` block using `for_each`, so its less redundant

This PR is ready for review, would love some feedback if somebody has the time and patience