### PR TITLE
fix(tffmt): fix CI and run terraform fmt

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,4 +13,5 @@ jobs:
         uses: hashicorp/setup-terraform@v2
           
       - name: Terraform fmt
-        run: make fmt
+        run: |
+          terraform fmt -check -recursive .

--- a/akamai-github/terraform/akamai/main.tf
+++ b/akamai-github/terraform/akamai/main.tf
@@ -13,15 +13,15 @@ terraform {
   }
   required_providers {
     linode = {
-      source = "linode/linode"
+      source  = "linode/linode"
       version = "2.16.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "2.23.0"
     }
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "3.19.0"
     }
   }
@@ -29,26 +29,26 @@ terraform {
 provider "linode" {}
 
 locals {
-  cluster_name = "<CLUSTER_NAME>"
+  cluster_name         = "<CLUSTER_NAME>"
   kube_config_filename = "../../../kubeconfig"
 }
 
 resource "linode_lke_cluster" "kubefirst" {
-    label       = local.cluster_name
-    k8s_version = "1.28"
-    region      = "us-central"
-    tags        = ["<CLUSTER_NAME>"]
+  label       = local.cluster_name
+  k8s_version = "1.28"
+  region      = "us-central"
+  tags        = ["<CLUSTER_NAME>"]
 
-    pool {
-        # NOTE: If count is undefined, the initial node count will
-        # equal the minimum autoscaler node count.
-        type  = "<NODE_TYPE>" # "g6-standard-4" 4
+  pool {
+    # NOTE: If count is undefined, the initial node count will
+    # equal the minimum autoscaler node count.
+    type = "<NODE_TYPE>" # "g6-standard-4" 4
 
-        autoscaler {
-          min = tonumber("<NODE_COUNT>") # tonumber() is used for a string token value
-          max = tonumber("<NODE_COUNT>") # tonumber() is used for a string token value
-        }
+    autoscaler {
+      min = tonumber("<NODE_COUNT>") # tonumber() is used for a string token value
+      max = tonumber("<NODE_COUNT>") # tonumber() is used for a string token value
     }
+  }
 }
 
 resource "local_file" "kubeconfig" {

--- a/akamai-github/terraform/users/modules/user/github/main.tf
+++ b/akamai-github/terraform/users/modules/user/github/main.tf
@@ -25,7 +25,7 @@ resource "random_password" "password" {
 }
 
 resource "vault_generic_endpoint" "user" {
-  depends_on = [ vault_generic_endpoint.user_password ] # avoids race condition
+  depends_on           = [vault_generic_endpoint.user_password] # avoids race condition
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
 
@@ -41,7 +41,7 @@ resource "vault_generic_endpoint" "user_password" {
   path                 = "auth/userpass/users/${var.username}"
   ignore_absent_fields = true
   lifecycle {
-    ignore_changes=[data_json]
+    ignore_changes = [data_json]
   }
 
   # note: this resource includes the initial password and only gets applied once

--- a/akamai-github/terraform/vault/kubernetes-auth-backend.tf
+++ b/akamai-github/terraform/vault/kubernetes-auth-backend.tf
@@ -4,13 +4,13 @@ provider "kubernetes" {
 
 data "linode_lke_clusters" "kubefirst" {
   filter {
-    name = "tags"
+    name   = "tags"
     values = ["<CLUSTER_NAME>"]
   }
 }
 
 data "linode_lke_cluster" "kubefirst" {
-    id = data.linode_lke_clusters.kubefirst.lke_clusters.0.id
+  id = data.linode_lke_clusters.kubefirst.lke_clusters.0.id
 }
 resource "vault_auth_backend" "k8s" {
   type = "kubernetes"

--- a/akamai-github/terraform/vault/main.tf
+++ b/akamai-github/terraform/vault/main.tf
@@ -13,7 +13,7 @@ terraform {
   }
   required_providers {
     linode = {
-      source = "linode/linode"
+      source  = "linode/linode"
       version = "2.16.0"
     }
     vault = {

--- a/akamai-github/terraform/vault/variables.tf
+++ b/akamai-github/terraform/vault/variables.tf
@@ -7,12 +7,12 @@ variable "b64_docker_auth" {
 }
 
 variable "cloudflare_origin_ca_api_key" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cloudflare_api_key" {
-  type = string
+  type    = string
   default = ""
 }
 


### PR DESCRIPTION
in #712 I added `make fmt` in the terraform GHA CI, which will only run `terraform fmt` but not check for proper formatting - sorry for that. This CI fixes this and formats all *.tf files correctly.