### PR TITLE
add config map to avoid argo from infinitely redirecting

### DIFF
--- a/google-github/templates/mgmt/components/argocd/argocd-cmd-params-cm.yaml
+++ b/google-github/templates/mgmt/components/argocd/argocd-cmd-params-cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  # ssl terminated at ingress-nginx and forwarded
+  # to allow for cloudflare origin issuer certificates
+  server.insecure: 'true'

--- a/google-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/google-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 
 patchesStrategicMerge:
   - argocd-cm.yaml
+  - argocd-cmd-params-cm.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/google-gitlab/templates/mgmt/components/argocd/argocd-cmd-params-cm.yaml
+++ b/google-gitlab/templates/mgmt/components/argocd/argocd-cmd-params-cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  # ssl terminated at ingress-nginx and forwarded
+  # to allow for cloudflare origin issuer certificates
+  server.insecure: 'true'

--- a/google-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/google-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 
 patchesStrategicMerge:
   - argocd-cm.yaml
+  - argocd-cmd-params-cm.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Add files from #597 to Google to avoid argocd.kubefirst.<domain> from infinitely redirecting to itself