### PR TITLE
remove delete protection from gke

### DIFF
--- a/google-github/terraform/google/gke/main.tf
+++ b/google-github/terraform/google/gke/main.tf
@@ -16,6 +16,8 @@ module "gke" {
   region          = var.google_region
   release_channel = "STABLE"
 
+  deletion_protection = false
+
   // External availability
   enable_private_endpoint = false
   enable_private_nodes    = true

--- a/google-gitlab/terraform/google/gke/main.tf
+++ b/google-gitlab/terraform/google/gke/main.tf
@@ -16,6 +16,8 @@ module "gke" {
   region          = var.google_region
   release_channel = "STABLE"
 
+  deletion_protection = false
+
   // External availability
   enable_private_endpoint = false
   enable_private_nodes    = true


### PR DESCRIPTION
The [deprovision instructions](https://docs.kubefirst.io/gcp/deprovision) don't work without `deletion_protection` set to false.

Defaulting to protecting clusters from being deleted [was added in v5](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) of the Terraform dependency.

The only question is whether this should be a configurable flag?