### PR TITLE
Add physical cluster templates to Google Cloud Project

### DIFF
--- a/google-github/templates/workload-cluster/0-providerconfig.yaml
+++ b/google-github/templates/workload-cluster/0-providerconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-provider-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/clusters/<WORKLOAD_CLUSTER_NAME>/provider-config
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: crossplane-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/10-infrastructure.yaml
+++ b/google-github/templates/workload-cluster/10-infrastructure.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-infrastructure
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '10'
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/clusters/<WORKLOAD_CLUSTER_NAME>/infrastructure
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: <WORKLOAD_CLUSTER_NAME>
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/20-argocd-connection.yaml
+++ b/google-github/templates/workload-cluster/20-argocd-connection.yaml
@@ -1,0 +1,63 @@
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
+  labels:
+    app.kubernetes.io/part-of: argocd
+spec:
+  target:
+    name: <WORKLOAD_CLUSTER_NAME>
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+      engineVersion: v2
+      data:
+        name: "{{ .cluster_name }}"
+        server: "{{ .host }}"
+        clusterResources: "true"
+        config: |
+          {
+            "bearerToken": "{{ .argocd_manager_sa_token }}",
+            "tlsClientConfig": {
+                "caData": "{{ .cluster_ca_certificate | b64enc }}",
+                "certData": "{{ .client_certificate | b64enc }}",
+                "insecure": false,
+                "keyData": "{{ .client_key | b64enc }}"
+              }
+          }
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: 10s
+  data:
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: argocd_manager_sa_token
+      secretKey: argocd_manager_sa_token
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: host
+      secretKey: host
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: cluster_name
+      secretKey: cluster_name
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: cluster_ca_certificate
+        conversionStrategy: Default
+      secretKey: cluster_ca_certificate
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: client_certificate
+        conversionStrategy: Default
+      secretKey: client_certificate
+    - remoteRef:
+        key: clusters/<WORKLOAD_CLUSTER_NAME>
+        property: client_key
+        conversionStrategy: Default
+      secretKey: client_key
+

--- a/google-github/templates/workload-cluster/30-cert-manager.yaml
+++ b/google-github/templates/workload-cluster/30-cert-manager.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-cert-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '30'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: https://charts.jetstack.io
+    targetRevision: v1.14.4
+    helm:
+      values: |-
+        serviceAccount:
+          create: true
+          name: cert-manager
+        installCRDs: true
+    chart: cert-manager
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/30-external-dns.yaml
+++ b/google-github/templates/workload-cluster/30-external-dns.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-external-dns
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '30'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: https://kubernetes-sigs.github.io/external-dns
+    targetRevision: 1.14.4
+    helm:
+      releaseName: external-dns
+      values: |
+        image:
+          repository: registry.k8s.io/external-dns/external-dns
+          tag: "v0.13.2"
+        serviceAccount:
+          create: true
+          name: external-dns
+        provider: google
+        sources:
+        - ingress
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/tmp/credentials.json"
+        domainFilters:
+        - <WORKLOAD_EXTERNAL_DNS_DOMAIN_NAME>
+        extraVolumes:
+        - name: secrets
+          secret:
+            secretName: external-dns
+        extraVolumeMounts:
+        - name: secrets
+          mountPath: /tmp
+    chart: external-dns
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: external-dns
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/30-external-secrets-operator.yaml
+++ b/google-github/templates/workload-cluster/30-external-secrets-operator.yaml
@@ -1,0 +1,71 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-external-secrets-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '30'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: https://charts.external-secrets.io
+    targetRevision: 0.8.1
+    helm:
+      values: |-
+        serviceAccount:
+          create: false
+          name: external-secrets
+    chart: external-secrets
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: external-secrets-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.conversion.webhook.clientConfig.caBundle
+        - .spec.conversion.webhook.clientConfig.service.name
+        - .spec.conversion.webhook.clientConfig.service.namespace
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-eso-kubernetes-external-secrets-auth
+  annotations:
+    argocd.argoproj.io/sync-wave: '40'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'system:auth-delegator'
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-eso-kubernetes-external-secrets-auth2
+  annotations:
+    argocd.argoproj.io/sync-wave: '40'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'cluster-admin'
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets-operator

--- a/google-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/google-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-ingress-nginx
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '30'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: https://kubernetes.github.io/ingress-nginx
+    targetRevision: 4.10.0
+    helm:
+      values: |-
+        controller:
+          podAnnotations:
+            linkerd.io/inject: enabled
+          ingressClass: nginx
+          publishService:
+            enabled: true
+          service:
+            annotations:
+              service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+              service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+          extraArgs:
+            enable-ssl-passthrough: true
+    chart: ingress-nginx
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: ingress-nginx
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/30-reloader.yaml
+++ b/google-github/templates/workload-cluster/30-reloader.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-reloader
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '30'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: 'https://stakater.github.io/stakater-charts'
+    targetRevision: v1.0.10
+    chart: reloader
+    helm:
+      values: |-
+        ignoreSecrets: false
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: reloader
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 5m0s
+        factor: 2

--- a/google-github/templates/workload-cluster/40-clusterissuers.yaml
+++ b/google-github/templates/workload-cluster/40-clusterissuers.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-cert-issuers
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '40'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/clusters/<WORKLOAD_CLUSTER_NAME>/cert-issuers
+    targetRevision: HEAD
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/40-clustersecretstore.yaml
+++ b/google-github/templates/workload-cluster/40-clustersecretstore.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-cluster-secret-store
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '40'
+spec:
+  project: <WORKLOAD_CLUSTER_NAME>
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/clusters/<WORKLOAD_CLUSTER_NAME>/cluster-secret-store
+    targetRevision: HEAD
+  destination:
+    name: <WORKLOAD_CLUSTER_NAME>
+    namespace: external-secrets-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/45-environment.yaml
+++ b/google-github/templates/workload-cluster/45-environment.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-environment
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: '45'
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/environments/<WORKLOAD_ENVIRONMENT>
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/google-github/templates/workload-cluster/appproject-workload-cluster.yaml
+++ b/google-github/templates/workload-cluster/appproject-workload-cluster.yaml
@@ -1,0 +1,55 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: <WORKLOAD_CLUSTER_NAME> description
+  sourceRepos:
+  - 'git@github.com:mrsimonemmsorg/gitops.git'
+  - 'https://kubernetes.github.io/ingress-nginx'
+  - 'https://kubernetes-sigs.github.io/external-dns'
+  - 'https://charts.jetstack.io'
+  - 'https://charts.external-secrets.io'
+  - 'https://helm.datadoghq.com'
+  - 'https://stakater.github.io/stakater-charts'
+  - 'https://chartmuseum.trygitops.com'
+  - 'https://charts.loft.sh'
+  - 'https://github.com/cloudflare/origin-ca-issuer'
+  - 'https://cloudflare.github.io/origin-ca-issuer/charts'
+  - '*' # Adding wildcard for the gitops catalog. This wildcard can be removed from the template or after provisioning
+  destinations:
+  - namespace: external-dns
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: datadog
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: default
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: <WORKLOAD_ENVIRONMENT>
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: external-secrets-operator
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: reloader
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: cert-manager
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: ingress-nginx
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: kube-system
+    name: <WORKLOAD_CLUSTER_NAME>
+  - namespace: '*' # Adding wildcard for the gitops catalog. This wildcard can be removed from the template or after provisioning
+    server: '*' # Adding wildcard for the gitops catalog. This wildcard can be removed from the template or after provisioning
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  roles:
+  - description: <WORKLOAD_CLUSTER_NAME>-admin-role
+    groups:
+    - admins
+    name: admin-role
+    policies:
+    - p, proj:<WORKLOAD_CLUSTER_NAME>:admin-role, applications, *, <WORKLOAD_CLUSTER_NAME>/*, allow

--- a/google-github/templates/workload-cluster/cert-issuers/clusterissuers.yaml
+++ b/google-github/templates/workload-cluster/cert-issuers/clusterissuers.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: simon@simonemms.com
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: simon@simonemms.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/google-github/templates/workload-cluster/cluster-secret-store/clustersecretstore.yaml
+++ b/google-github/templates/workload-cluster/cluster-secret-store/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-vault-kv-secret
+  annotations:
+    argocd.argoproj.io/sync-wave: '10'
+spec:
+  provider:
+    vault:
+      server: 'https://vault.trygitops.com'
+      path: 'secret'
+      version: 'v2'
+      auth:
+        # points to a secret that contains a vault token
+        # https://www.vaultproject.io/docs/auth/token
+        tokenSecretRef:
+          name: "<WORKLOAD_CLUSTER_NAME>-cluster-vault-bootstrap"
+          key: "vault-token"

--- a/google-github/templates/workload-cluster/infrastructure/wait.yaml
+++ b/google-github/templates/workload-cluster/infrastructure/wait.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>-infrastructure-wait
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  template:
+    spec:
+      serviceAccountName: argocd-server
+      containers:
+      - name: wait
+        image: bitnami/kubectl:1.25.12
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while ! kubectl wait --for=jsonpath='{.status.conditions[0].status}'='True' workspace/<WORKLOAD_CLUSTER_NAME>; do echo "waiting for cluster to provision"; sleep 5; done
+      restartPolicy: Never
+  backoffLimit: 1

--- a/google-github/templates/workload-cluster/infrastructure/workspace.yaml
+++ b/google-github/templates/workload-cluster/infrastructure/workspace.yaml
@@ -1,0 +1,324 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    crossplane.io/external-name: <WORKLOAD_CLUSTER_NAME>
+spec:
+  providerConfigRef:
+    name: <WORKLOAD_CLUSTER_NAME>
+  forProvider:
+    source: Inline
+    module: |
+      variable "instance_size" {
+        type    = string
+        default = "e2-medium"
+      }
+
+      variable "region" {
+        type    = string
+        default = "europe-west1"
+      }
+
+      variable "node_count" {
+        type    = number
+        default = "<WORKLOAD_NODE_COUNT>"
+      }
+
+      locals {
+        cluster_name = "kf-<WORKLOAD_CLUSTER_NAME>"
+        subnet_name  = lookup(module.vpc.subnets, "${var.region}/subnet-01-${local.cluster_name}").name
+      }
+
+      data "google_client_config" "current" {}
+
+      resource "google_service_account" "kubefirst" {
+        account_id   = local.cluster_name
+        display_name = "Service Account for ${local.cluster_name} cluster"
+      }
+
+      module "vpc" {
+        source  = "terraform-google-modules/network/google"
+        version = "~> 9.1"
+
+        project_id   = data.google_client_config.current.project
+        network_name = local.cluster_name
+
+        subnets = [
+          {
+            subnet_name           = "subnet-01-${local.cluster_name}"
+            subnet_ip             = "10.10.10.0/24"
+            subnet_region         = var.region
+            subnet_private_access = "true"
+            subnet_flow_logs      = "true"
+            description           = "This base subnet."
+          },
+        ]
+
+        secondary_ranges = {
+          "subnet-01-${local.cluster_name}" = [
+            {
+              range_name    = "subnet-01-${local.cluster_name}-gke-01-pods"
+              ip_cidr_range = "10.13.0.0/16"
+            },
+            {
+              range_name    = "subnet-01-${local.cluster_name}-gke-01-services"
+              ip_cidr_range = "10.14.0.0/16"
+            },
+          ]
+        }
+      }
+
+      module "gke" {
+        source = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+
+        project_id               = data.google_client_config.current.project
+        name                     = local.cluster_name
+        region                   = var.region
+        release_channel          = "STABLE"
+        remove_default_node_pool = true
+
+        deletion_protection = false
+
+        // External availability
+        enable_private_endpoint = false
+        enable_private_nodes    = true
+
+        // Service Account
+        create_service_account = true
+
+        // Networking
+        network           = module.vpc.network_name
+        subnetwork        = local.subnet_name
+        ip_range_pods     = "${local.subnet_name}-gke-01-pods"
+        ip_range_services = "${local.subnet_name}-gke-01-services"
+
+        // Addons
+        dns_cache                  = true
+        enable_shielded_nodes      = true
+        filestore_csi_driver       = false
+        gce_pd_csi_driver          = true
+        horizontal_pod_autoscaling = false
+        http_load_balancing        = false
+        network_policy             = false
+
+        // Node Pools
+        node_pools = [
+          {
+            name      = "kubefirst"
+            node_type = var.instance_size
+
+            // Autoscaling
+            // PER ZONE
+            min_count = var.node_count
+            // PER ZONE
+            max_count = var.node_count
+            // PER ZONE
+            initial_node_count = var.node_count
+
+            local_ssd_count = 0
+            spot            = false
+            disk_size_gb    = 100
+            disk_type       = "pd-standard"
+            image_type      = "COS_CONTAINERD"
+            enable_gcfs     = false
+            enable_gvnic    = false
+            auto_repair     = true
+            auto_upgrade    = true
+            preemptible     = false
+          },
+        ]
+
+        node_pools_oauth_scopes = {
+          all = [
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring",
+            "https://www.googleapis.com/auth/devstorage.read_only",
+          ]
+        }
+      }
+
+      resource "vault_generic_secret" "clusters" {
+        path = "secret/clusters/${local.cluster_name}"
+
+        data_json = jsonencode(
+          {
+            cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+            host                   = "https://${module.gke.endpoint}"
+            token                  = data.google_client_config.current.access_token
+            cluster_name           = local.cluster_name
+            argocd_manager_sa_token = kubernetes_secret_v1.argocd_manager.data.token
+          }
+        )
+      }
+
+      provider "kubernetes" {
+        host                   = "https://${module.gke.endpoint}"
+        token                  = data.google_client_config.current.access_token
+        cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+      }
+
+      resource "kubernetes_cluster_role_v1" "argocd_manager" {
+        metadata {
+          name = "argocd-manager-role"
+        }
+
+        rule {
+          api_groups = ["*"]
+          resources  = ["*"]
+          verbs      = ["*"]
+        }
+        rule {
+          non_resource_urls = ["*"]
+          verbs = ["*"]
+        }
+      }
+
+      resource "kubernetes_cluster_role_binding_v1" "argocd_manager" {
+        metadata {
+          name = "argocd-manager-role-binding"
+        }
+        role_ref {
+          api_group = "rbac.authorization.k8s.io"
+          kind      = "ClusterRole"
+          name      = kubernetes_cluster_role_v1.argocd_manager.metadata.0.name
+        }
+        subject {
+          kind      = "ServiceAccount"
+          name      = kubernetes_service_account_v1.argocd_manager.metadata.0.name
+          namespace = "kube-system"
+        }
+      }
+
+      resource "kubernetes_service_account_v1" "argocd_manager" {
+        metadata {
+          name = "argocd-manager"
+          namespace = "kube-system"
+        }
+        secret {
+          name = "argocd-manager-token"
+        }
+      }
+
+      resource "kubernetes_secret_v1" "argocd_manager" {
+        metadata {
+          name = "argocd-manager-token"
+          namespace = "kube-system"
+          annotations = {
+            "kubernetes.io/service-account.name" = "argocd-manager"
+          }
+        }
+        type = "kubernetes.io/service-account-token"
+        depends_on = [ kubernetes_service_account_v1.argocd_manager ]
+      }
+
+      resource "kubernetes_namespace_v1" "external_dns" {
+        metadata {
+          name = "external-dns"
+        }
+      }
+
+      data "vault_generic_secret" "external_dns" {
+        path = "secret/external-dns"
+      }
+
+      resource "kubernetes_secret_v1" "external_dns" {
+        metadata {
+          name = "external-dns-secrets"
+          namespace = kubernetes_namespace_v1.external_dns.metadata.0.name
+        }
+        data = {
+          token = data.vault_generic_secret.external_dns.data["token"]
+        }
+        type = "Opaque"
+      }
+
+
+      resource "kubernetes_namespace_v1" "external_secrets_operator" {
+        metadata {
+          name = "external-secrets-operator"
+        }
+      }
+
+      resource "kubernetes_namespace_v1" "environment" {
+        metadata {
+          name = "<WORKLOAD_CLUSTER_NAME>"
+        }
+      }
+
+      data "vault_generic_secret" "docker_config" {
+        path = "secret/dockerconfigjson"
+      }
+
+      resource "kubernetes_secret_v1" "image_pull" {
+        metadata {
+          name = "docker-config"
+          namespace = kubernetes_namespace_v1.environment.metadata.0.name
+        }
+
+        data = {
+          ".dockerconfigjson" = data.vault_generic_secret.docker_config.data["dockerconfig"]
+        }
+
+        type = "kubernetes.io/dockerconfigjson"
+      }
+
+      data "vault_generic_secret" "external_secrets_operator" {
+        path = "secret/atlantis"
+      }
+
+      resource "kubernetes_secret_v1" "external_secrets_operator_environment" {
+        metadata {
+          name = "${local.cluster_name}-cluster-vault-bootstrap"
+          namespace = kubernetes_namespace_v1.environment.metadata.0.name
+        }
+        data = {
+          vault-token = data.vault_generic_secret.external_secrets_operator.data["VAULT_TOKEN"]
+        }
+        type = "Opaque"
+      }
+
+      resource "kubernetes_secret_v1" "external_secrets_operator" {
+        metadata {
+          name = "${local.cluster_name}-cluster-vault-bootstrap"
+          namespace = kubernetes_namespace_v1.external_secrets_operator.metadata.0.name
+        }
+        data = {
+          vault-token = data.vault_generic_secret.external_secrets_operator.data["VAULT_TOKEN"]
+        }
+        type = "Opaque"
+      }
+
+      resource "kubernetes_service_account_v1" "external_secrets" {
+        metadata {
+          name = "external-secrets"
+          namespace = kubernetes_namespace_v1.external_secrets_operator.metadata.0.name
+        }
+        secret {
+          name = "external-secrets-token"
+        }
+      }
+
+      resource "kubernetes_secret_v1" "external_secrets" {
+        metadata {
+          name = "external-secrets-token"
+          namespace = kubernetes_namespace_v1.external_secrets_operator.metadata.0.name
+          annotations = {
+            "kubernetes.io/service-account.name" = "external-secrets"
+          }
+        }
+        type = "kubernetes.io/service-account-token"
+        depends_on = [ kubernetes_service_account_v1.external_secrets ]
+      }
+
+      resource "kubernetes_config_map" "kubefirst_cm" {
+        metadata {
+          name = "kubefirst-cm"
+          namespace = "kube-system"
+        }
+
+        data = {
+          mgmt_cluster_id = "<CLUSTER_ID>"
+        }
+      }

--- a/google-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/google-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -1,0 +1,50 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: <WORKLOAD_CLUSTER_NAME>
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  configuration: |
+      terraform {
+        backend "gcs" {
+          bucket   = "k1-state-store-sje-trygitops-aon17u"
+          prefix   = "registry/clusters/<WORKLOAD_CLUSTER_NAME>/infrastructure/provider-config/terraform.tfstate"
+        }
+        required_providers {
+          google = {
+            source = "hashicorp/google"
+            version = "5.35.0"
+          }
+          kubernetes = {
+            source = "hashicorp/kubernetes"
+            version = "2.23.0"
+          }
+          vault = {
+            source = "hashicorp/vault"
+            version = "3.19.0"
+          }
+        }
+      }
+      provider "google" {
+        project = "<GOOGLE_PROJECT>"
+      }
+  credentials:
+  - filename: gen-nothing
+    source: None
+    secretRef:
+      namespace: crossplane-system
+      name: civo-creds
+      key: token
+  - filename: .git-credentials
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: git-credentials
+      key: creds
+  - filename: gcp-credentials
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: gcp-credentials
+      key: creds

--- a/google-github/templates/workload-cluster/registry-workload-cluster.yaml
+++ b/google-github/templates/workload-cluster/registry-workload-cluster.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: registry-<WORKLOAD_CLUSTER_NAME>
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:mrsimonemmsorg/gitops.git
+    path: registry/clusters/<WORKLOAD_CLUSTER_NAME>
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 5m0s
+        factor: 2


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds the option to create a physical GKE cluster in Kubefirst

Before this is merged, I have a couple of questions about how this should be done best.
* The console has "cloud zone" as a required field, but I've done this across all zones which arguably better for prod-grade clusters. Should we change the console to cater for per-zone and multi-zone?
* The console assumes a static number of nodes - should we allow autoscaling with min/max nodes and static number of nodes?

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #765

## How to test
<!-- Provide steps to test this PR -->
> I have a dev version running. I can sync with reviewer(s) to use this
1. Create a dev deployment of Kubefirst to Google
2. Create a physical cluster in the dashboard
3. Profit

NB. Physical clusters in GCP are a paid-feature. There is a [Posthog feature flag](https://us.posthog.com/project/24219/feature_flags/22109) to allow this for a development version only.