### PR TITLE
feat : custom repo for civo

### DIFF
--- a/civo-github/terraform/github/repos.tf
+++ b/civo-github/terraform/github/repos.tf
@@ -26,7 +26,7 @@ terraform {
 module "gitops" {
   source = "./modules/repository"
 
-  repo_name          = "gitops"
+  repo_name          = "<GIT-REPO-NAME>"
   archive_on_destroy = false
   auto_init          = false # set to false if importing an existing repository
   team_developers_id = github_team.developers.id
@@ -55,7 +55,7 @@ variable "atlantis_repo_webhook_secret" {
 module "metaphor" {
   source = "./modules/repository"
 
-  repo_name          = "metaphor"
+  repo_name          = "<METPAHOR-REPO-NAME>"
   archive_on_destroy = false
   auto_init          = false # set to false if importing an existing repository
   create_ecr         = true

--- a/civo-github/terraform/github/teams.tf
+++ b/civo-github/terraform/github/teams.tf
@@ -1,11 +1,11 @@
 resource "github_team" "admins" {
-  name        = <ADMIN-TEAM>
+  name        = "<ADMIN-TEAM>"
   description = "administrators of the kubefirst platform"
   privacy     = "closed"
 }
 
 resource "github_team" "developers" {
-  name        = <DEVELOPER-TEAM>
+  name        = "<DEVELOPER-TEAM>"
   description = "developers using the kubefirst plaftform"
   privacy     = "closed"
 }

--- a/civo-github/terraform/github/teams.tf
+++ b/civo-github/terraform/github/teams.tf
@@ -1,11 +1,11 @@
 resource "github_team" "admins" {
-  name        = "admins"
+  name        = <ADMIN-TEAM>
   description = "administrators of the kubefirst platform"
   privacy     = "closed"
 }
 
 resource "github_team" "developers" {
-  name        = "developers"
+  name        = <DEVELOPER-TEAM>
   description = "developers using the kubefirst plaftform"
   privacy     = "closed"
 }

--- a/civo-github/terraform/users/admins/data_sources.tf
+++ b/civo-github/terraform/users/admins/data_sources.tf
@@ -1,5 +1,5 @@
 data "github_team" "admins" {
-  slug = "admins"
+  slug = "<ADMIN-TEAM>"
 }
 
 data "vault_auth_backend" "userpass" {

--- a/civo-github/terraform/users/developers/data_sources.tf
+++ b/civo-github/terraform/users/developers/data_sources.tf
@@ -1,5 +1,5 @@
 data "github_team" "developers" {
-  slug = "developers"
+  slug = "<DEVELOPER-TEAM>"
 }
 
 data "vault_auth_backend" "userpass" {

--- a/civo-github/terraform/users/users.tf
+++ b/civo-github/terraform/users/users.tf
@@ -20,11 +20,11 @@ terraform {
 }
 
 data "github_team" "admins" {
-  slug = "admins"
+  slug = "<ADMIN-TEAM>"
 }
 
 data "github_team" "developers" {
-  slug = "developers"
+  slug = "<DEVELOPER-TEAM>"
 }
 
 data "vault_auth_backend" "userpass" {


### PR DESCRIPTION
we can now deploy multiple repos on same organistation using below  flags : 

 "--gitopsRepoName" metaphorRepoName "adminTeamName" "developerTeamName"

but we have to use kubefirst repo branch "feat-custom-repo" and kubefirst-api repo branch "feat-custom-repo" until its merged into main