### PR TITLE
fix: remove hard coded Kubernetes version for managment cluster

### DIFF
--- a/digitalocean-github/terraform/digitalocean/main.tf
+++ b/digitalocean-github/terraform/digitalocean/main.tf
@@ -33,9 +33,7 @@ locals {
   kube_config_filename = "../../../kubeconfig"
 }
 
-data "digitalocean_kubernetes_versions" "versions" {
-  version_prefix = "1.27."
-}
+data "digitalocean_kubernetes_versions" "versions" {}
 
 resource "digitalocean_kubernetes_cluster" "kubefirst" {
   name    = local.cluster_name

--- a/digitalocean-gitlab/terraform/digitalocean/main.tf
+++ b/digitalocean-gitlab/terraform/digitalocean/main.tf
@@ -32,9 +32,7 @@ locals {
   kube_config_filename = "../../../kubeconfig"
 }
 
-data "digitalocean_kubernetes_versions" "versions" {
-  version_prefix = "1.27."
-}
+data "digitalocean_kubernetes_versions" "versions" {}
 
 resource "digitalocean_kubernetes_cluster" "kubefirst" {
   name    = local.cluster_name


### PR DESCRIPTION
DigitalOcean ended support for Kubernetes v1.27 on 28 June 2024. As a result Kubefirst(Terraform) is not able to provision a cluster.
[DigitalOcean Kubernetes Supported Releases](https://docs.digitalocean.com/products/kubernetes/details/supported-releases/)

## Description
To fix this issue, this PR removes the hard coded Kubernetes version and instead use `digitalocean_kubernetes_versions` datasource to fetch the latest version that DigitalOcean supports. Downside of this change it that the new Kubernetes release might introduce breaking changes.

