### PR TITLE
fix(aws-gitlab): update gitlab url for image registry secret

### DIFF
--- a/aws-gitlab/terraform/vault/secrets.tf
+++ b/aws-gitlab/terraform/vault/secrets.tf
@@ -34,7 +34,7 @@ resource "vault_generic_secret" "docker_config" {
 
   data_json = jsonencode(
     {
-      dockerconfig = jsonencode({ "auths" : { "registry.gitlab.io" : { "auth" : "${var.b64_docker_auth}" } } }),
+      dockerconfig = jsonencode({ "auths" : { "registry.gitlab.com" : { "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The root cause was actually that the URL was set to `registry.gitlab.io` rather than `registry.gitlab.com`

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes https://github.com/kubefirst/kubefirst/issues/2256

## How to test
<!-- Provide steps to test this PR -->
Deploy to AWS GitLab, using instructions from #783 
