### PR TITLE
fix: force replace Job during a sync

### DIFF
--- a/akamai-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/akamai-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/akamai-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/akamai-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/aws-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/aws-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/aws-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/aws-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true    
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/aws-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/aws-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/aws-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/aws-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/civo-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/civo-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/civo-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/civo-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/civo-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/civo-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/civo-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/civo-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/digitalocean-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/digitalocean-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/digitalocean-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/digitalocean-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/digitalocean-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/digitalocean-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/google-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/google-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true
+      

--- a/google-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/google-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/google-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/google-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/google-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/google-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/vultr-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/vultr-github/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/vultr-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/vultr-github/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:

--- a/vultr-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
+++ b/vultr-gitlab/templates/mgmt/components/argo-workflows/vault-wait.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true

--- a/vultr-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
+++ b/vultr-gitlab/templates/mgmt/components/argo-workflows/wait/vault-tls.yaml
@@ -23,6 +23,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: '0'
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: wait-vault-tls
   namespace: vault
 spec:


### PR DESCRIPTION
## Description
A Job resource is an immutable resource. Changes to spec.template causes a sync error. Add annotation to force replaces Job resources.

Remove  the sync option "replace" from vault-wait ArgoCD app and add to the Job resource as SA and CRB resources do not need to be replaced.

## Related Issue(s)

https://github.com/kubefirst/kubefirst/issues/2264

## How to test
Provision a management cluster and verify `vault-wait` job is healthy.
